### PR TITLE
Allow reading/writing to a manifest file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flux-local
-version = 0.0.2
+version = 0.0.3
 description = flux-local is a python library and set of tools for managing a flux gitops repository, with validation steps to help improve quality of commits, PRs, and general local testing.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Allow reading/writing to a manifest file. Writing a manifest file can be useful to checkpoint all the expected primary artifacts of the cluster and used for driving tests, where just discovering artifacts form the cluster may result in unexpectedly missing some (e.g. if a kustomization is misconfigured)
