### PR TITLE
Streamline manifest output format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flux-local
-version = 0.0.3
+version = 0.0.4
 description = flux-local is a python library and set of tools for managing a flux gitops repository, with validation steps to help improve quality of commits, PRs, and general local testing.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Update the manifest data model to include `HelmRelease` `values`. The manifest is compacted when persisted, and now the same object can be used for a raw release, or just persisted manifest.

Increase a breaking change to update all objects to be pyndantic models to simplify how exclusion works so that it can work on nested objects.
