### PR TITLE
Fix link to documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ cluster is creating valid objects.
 This library at first glance is little more than shell scripts running commands, but is easier
 to test, maintain, and evolve.
 
-See [documentation](https://allenporter.github.io/ical/) for full quickstart and API reference.
+See [documentation](https://allenporter.github.io/flux-local/) for full quickstart and API reference.
 See the [github project](https://github.com/allenporter/flux-local).


### PR DESCRIPTION
I think the link is currently pointing to the wrong project :-)