### PR TITLE
Share flags and building between commands for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ infra-configs        ./tests/testdata/cluster/infrastructure/configs
 
 This example lists all HelmReleases in the cluster:
 ```bash
-$ flux-local get hr
+$ flux-local get hr -A
 NAMESPACE    NAME       REVISION    CHART              SOURCE
 podinfo      podinfo    >=1.0.0     podinfo-podinfo    podinfo
 metallb      metallb    4.1.14      metallb-metallb    bitnami
 ```
 
 This example lists all HelmReleases in a specific namespace:
-$ flux-local get hr  -n metallb
+$ flux-local get hr -n metallb
 NAME       REVISION    CHART              SOURCE
 metallb    4.1.14      metallb-metallb    bitnami
 ```

--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -9,9 +9,15 @@ from unit tests).
 Example usage:
 
 ```python
-from flux_local import repo
+from flux_local import git_repo
 
-manifest = await repo.build_manifest()
+
+selector = git_repo.Selector(
+    helm_release=git_repo.MetadataSelector(
+        namespace="podinfo"
+    )
+)
+manifest = await git_repo.build_manifest(selector)
 for cluster in manifest:
     print(f"Found cluster: {cluster.path}")
     for kustomization in cluster.kustomizations:
@@ -46,7 +52,6 @@ from .manifest import (
 )
 
 __all__ = [
-    "repo_root",
     "build_manifest",
     "ResourceSelector",
     "PathSelector",

--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -170,6 +170,9 @@ class Kustomization(BaseModel):
     name: str
     """The name of the kustomization."""
 
+    namespace: str | None = None
+    """The namespace of the kustomization."""
+
     path: str
     """The local repo path to the kustomization."""
 
@@ -187,11 +190,13 @@ class Kustomization(BaseModel):
             raise ValueError(f"Invalid {cls} missing metadata: {doc}")
         if not (name := metadata.get("name")):
             raise ValueError(f"Invalid {cls} missing metadata.name: {doc}")
+        if not (namespace := metadata.get("namespace")):
+            raise ValueError(f"Invalid {cls} missing metadata.namespace: {doc}")
         if not (spec := doc.get("spec")):
             raise ValueError(f"Invalid {cls} missing spec: {doc}")
         if not (path := spec.get("path")):
             raise ValueError(f"Invalid {cls} missing spec.path: {doc}")
-        return Kustomization(name=name, path=path)
+        return Kustomization(name=name, namespace=namespace, path=path)
 
     @property
     def id_name(self) -> str:

--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -49,18 +49,23 @@ async def build(
 ) -> AsyncGenerator[str, None]:
     """Flux-local build action."""
     root = git_repo.repo_root(git_repo.git_repo(path))
-    manifest = await git_repo.build_manifest(path)
+    query = git_repo.ResourceSelector()
+    query.path = git_repo.PathSelector(path)
+    query.kustomization.namespace = None
+    query.helm_release.namespace = None
+    manifest = await git_repo.build_manifest(selector=query)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        await mkdir(pathlib.Path(tmp_dir) / "cache")
+        cache_path = pathlib.Path(tmp_dir) / "cache"
+        await mkdir(cache_path)
 
         for cluster in manifest.clusters:
             helm = None
             if enable_helm:
-                path = pathlib.Path(tmp_dir) / f"{slugify(cluster.path)}"
-                await mkdir(path)
+                helm_path = pathlib.Path(tmp_dir) / f"{slugify(cluster.path)}"
+                await mkdir(helm_path)
 
-                helm = Helm(path, pathlib.Path(tmp_dir) / "cache")
+                helm = Helm(helm_path, cache_path)
                 helm.add_repos(cluster.helm_repos)
                 await helm.update()
 

--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -48,7 +48,6 @@ async def build(
     path: pathlib.Path, enable_helm: bool, skip_crds: bool
 ) -> AsyncGenerator[str, None]:
     """Flux-local build action."""
-    root = git_repo.repo_root(git_repo.git_repo(path))
     query = git_repo.ResourceSelector()
     query.path = git_repo.PathSelector(path)
     query.kustomization.namespace = None
@@ -71,7 +70,7 @@ async def build(
 
             for kustomization in cluster.kustomizations:
                 async for content in build_kustomization(
-                    root, kustomization, helm, skip_crds
+                    query.path.root, kustomization, helm, skip_crds
                 ):
                     yield content
 

--- a/flux_local/tool/selector.py
+++ b/flux_local/tool/selector.py
@@ -1,10 +1,12 @@
 """Library for common selectors."""
 
+import logging
 import pathlib
 from argparse import ArgumentParser, BooleanOptionalAction
 
 from flux_local import git_repo
 
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAMESPACE = "flux-system"
 
@@ -53,14 +55,10 @@ def build_ks_selector(  # type: ignore[no-untyped-def]
     """Build a selector object form the specified flags."""
     selector = git_repo.ResourceSelector()
     selector.path = git_repo.PathSelector(kwargs.get("path"))
-    kustomization = kwargs.get("kustomization")
-    namespace = kwargs.get("namespace")
+    selector.kustomization.name = kwargs.get("kustomization")
+    selector.kustomization.namespace = kwargs.get("namespace")
     if kwargs.get("all_namespaces"):
-        namespace = None
-    if kustomization or namespace:
-        selector.kustomization = git_repo.MetadataSelector(
-            name=kustomization, namespace=namespace
-        )
+        selector.kustomization.namespace = None
     return selector
 
 
@@ -80,16 +78,13 @@ def build_hr_selector(  # type: ignore[no-untyped-def]
     **kwargs,
 ) -> git_repo.ResourceSelector:
     """Build a selector object form the specified flags."""
+    _LOGGER.debug("Building HelmRelease selector from args: %s", kwargs)
     selector = git_repo.ResourceSelector()
     selector.path = git_repo.PathSelector(kwargs.get("path"))
-    helmrelease = kwargs.get("helmrelease")
-    namespace = kwargs.get("namespace")
+    selector.helm_release.name = kwargs.get("helmrelease")
+    selector.helm_release.namespace = kwargs.get("namespace")
     if kwargs.get("all_namespaces"):
-        namespace = None
-    if helmrelease or namespace:
-        selector.helm_release = git_repo.MetadataSelector(
-            name=helmrelease, namespace=namespace
-        )
+        selector.helm_release.namespace = None
     return selector
 
 

--- a/flux_local/tool/selector.py
+++ b/flux_local/tool/selector.py
@@ -1,0 +1,104 @@
+"""Library for common selectors."""
+
+import pathlib
+from argparse import ArgumentParser, BooleanOptionalAction
+
+from flux_local import git_repo
+
+
+DEFAULT_NAMESPACE = "flux-system"
+
+
+def add_selector_flags(args: ArgumentParser) -> None:
+    """Add common selector flags to the arguments object."""
+    args.add_argument(
+        "--path",
+        help="Optional path with flux Kustomization resources (multi-cluster ok)",
+        type=pathlib.Path,
+        default=".",
+        nargs="?",
+    )
+    args.add_argument(
+        "--all-namespaces",
+        "-A",
+        type=bool,
+        default=False,
+        action=BooleanOptionalAction,
+        help="List the requested objects across all namespaces.",
+    )
+    args.add_argument(
+        "--namespace",
+        "-n",
+        type=str,
+        default=DEFAULT_NAMESPACE,
+        help="If present, the namespace scope for this request",
+    )
+
+
+def add_ks_selector_flags(args: ArgumentParser) -> None:
+    """Add common kustomization selector flags to the arguments object."""
+    args.add_argument(
+        "kustomization",
+        help="The name of the flux Kustomization",
+        type=str,
+        default=None,
+        nargs="?",
+    )
+    add_selector_flags(args)
+
+
+def build_ks_selector(  # type: ignore[no-untyped-def]
+    **kwargs,
+) -> git_repo.ResourceSelector:
+    """Build a selector object form the specified flags."""
+    selector = git_repo.ResourceSelector()
+    selector.path = git_repo.PathSelector(kwargs.get("path"))
+    kustomization = kwargs.get("kustomization")
+    namespace = kwargs.get("namespace")
+    if kwargs.get("all_namespaces"):
+        namespace = None
+    if kustomization or namespace:
+        selector.kustomization = git_repo.MetadataSelector(
+            name=kustomization, namespace=namespace
+        )
+    return selector
+
+
+def add_hr_selector_flags(args: ArgumentParser) -> None:
+    """Add common HelmRelease selector flags to the arguments object."""
+    args.add_argument(
+        "helmrelease",
+        help="The name of the flux Kustomization",
+        type=str,
+        default=None,
+        nargs="?",
+    )
+    add_selector_flags(args)
+
+
+def build_hr_selector(  # type: ignore[no-untyped-def]
+    **kwargs,
+) -> git_repo.ResourceSelector:
+    """Build a selector object form the specified flags."""
+    selector = git_repo.ResourceSelector()
+    selector.path = git_repo.PathSelector(kwargs.get("path"))
+    helmrelease = kwargs.get("helmrelease")
+    namespace = kwargs.get("namespace")
+    if kwargs.get("all_namespaces"):
+        namespace = None
+    if helmrelease or namespace:
+        selector.helm_release = git_repo.MetadataSelector(
+            name=helmrelease, namespace=namespace
+        )
+    return selector
+
+
+def not_found(resource: str, mds: git_repo.MetadataSelector) -> str:
+    """Return a not found error message for the given resource type and query."""
+    if mds.name:
+        return (
+            f"{resource} object '{mds.name}' not found in '{mds.namespace}' namespace"
+        )
+    if mds.namespace:
+        return f"no {resource} objects found in '{mds.namespace}' namespace"
+    return "no {resource} objects found in cluster"

--- a/tests/testdata/cluster/apps/prod/configmap.yaml
+++ b/tests/testdata/cluster/apps/prod/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   name: podinfo-config
   namespace: podinfo
 data:
-  foo: "bar"
+  foo: "baz"

--- a/tests/testdata/cluster/apps/prod/configmap.yaml
+++ b/tests/testdata/cluster/apps/prod/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   name: podinfo-config
   namespace: podinfo
 data:
-  foo: "baz"
+  foo: "bar"


### PR DESCRIPTION
Update the `git_repo` building to have a shared selectors for querying cluster objects. These are now shared between `flux-local` commands `get`, `diff`, and `build` and shared across resource types.