### PR TITLE
Fix default namespace selection for HelmReleases to return all

### DIFF
--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -130,7 +130,7 @@ class MetadataSelector:
     name: str | None = None
     """Resources returned will match this name."""
 
-    namespace: str | None = DEFAULT_NAMESPACE
+    namespace: str | None = None
     """Resources returned will be from this namespace."""
 
     @property
@@ -147,6 +147,11 @@ class MetadataSelector:
         return predicate
 
 
+def ks_metadata_selector() -> MetadataSelector:
+    """Create a new MetadataSelector for Kustomizations."""
+    return MetadataSelector(namespace=DEFAULT_NAMESPACE)
+
+
 @dataclass
 class ResourceSelector:
     """A filter for objects to select from the cluster.
@@ -159,7 +164,7 @@ class ResourceSelector:
     path: PathSelector = field(default_factory=PathSelector)
     """Path to find a repo of local flux Kustomization objects"""
 
-    kustomization: MetadataSelector = field(default_factory=MetadataSelector)
+    kustomization: MetadataSelector = field(default_factory=ks_metadata_selector)
     """Kustomization names to return, or all if empty."""
 
     helm_release: MetadataSelector = field(default_factory=MetadataSelector)

--- a/tests/testdata/flux_local/get_ks.yaml
+++ b/tests/testdata/flux_local/get_ks.yaml
@@ -3,6 +3,6 @@ args:
 - ks
 stdout: |
   NAME                 PATH                                                   HELMREPOS    RELEASES    
-  apps                 ./tests/testdata/cluster/apps/prod                     0            0           
-  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            0           
+  apps                 ./tests/testdata/cluster/apps/prod                     0            1           
+  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            1           
   infra-configs        ./tests/testdata/cluster/infrastructure/configs        2            0           

--- a/tests/testdata/flux_local/manifest.yaml
+++ b/tests/testdata/flux_local/manifest.yaml
@@ -11,12 +11,24 @@ stdout: |+
       namespace: flux-system
       path: ./tests/testdata/cluster/apps/prod
       helm_repos: []
-      helm_releases: []
+      helm_releases:
+      - name: podinfo
+        namespace: podinfo
+        chart:
+          name: podinfo
+          repo_name: podinfo
+          repo_namespace: podinfo
     - name: infra-controllers
       namespace: flux-system
       path: ./tests/testdata/cluster/infrastructure/controllers
       helm_repos: []
-      helm_releases: []
+      helm_releases:
+      - name: metallb
+        namespace: metallb
+        chart:
+          name: metallb
+          repo_name: bitnami
+          repo_namespace: flux-system
     - name: infra-configs
       namespace: flux-system
       path: ./tests/testdata/cluster/infrastructure/configs


### PR DESCRIPTION
Update the default namespace selection to allow all namespaces. The previous behavior of a default namespace was intended for Kustomizations, which is preserved. Also the command line tool sets a default namespace already, preserving behavior.