### PR TITLE
Speed up manifest building by parallelizing

### DIFF
--- a/flux_local/kustomize.py
+++ b/flux_local/kustomize.py
@@ -124,6 +124,16 @@ class Kustomize:
         ]
         await run_piped(cmds)
 
+    async def stash(self, tmp_file: Path) -> "Kustomize":
+        """Output the contents built so far to disk for efficient reuse.
+
+        This is useful to serialize a chain of commands but allow further
+        chaining with multiple branches.
+        """
+        content = await self.run()
+        tmp_file.write_text(content)
+        return Kustomize([Command(["cat", str(tmp_file)])])
+
 
 def build(path: Path) -> Kustomize:
     """Build cluster artifacts from the specified path."""

--- a/tests/test_kustomize.py
+++ b/tests/test_kustomize.py
@@ -62,6 +62,25 @@ async def test_objects(path: Path) -> None:
     "path",
     [TESTDATA_DIR / "repo", (TESTDATA_DIR / "repo").absolute()],
 )
+async def test_stash(path: Path, tmp_path: Path) -> None:
+    """Test loading yaml documents."""
+    cmd = await kustomize.build(path).stash(tmp_path / "stash")
+    result = await cmd.grep("kind=ConfigMap").objects()
+    assert len(result) == 1
+    assert result[0].get("kind") == "ConfigMap"
+    assert result[0].get("apiVersion") == "v1"
+    result = await cmd.grep("kind=Secret").objects()
+    assert len(result) == 1
+    assert result[0].get("kind") == "Secret"
+    assert result[0].get("apiVersion") == "v1"
+    result = await cmd.grep("kind=Unknown").objects()
+    assert len(result) == 0
+
+
+@pytest.mark.parametrize(
+    "path",
+    [TESTDATA_DIR / "repo", (TESTDATA_DIR / "repo").absolute()],
+)
 async def test_validate_pass(path: Path) -> None:
     """Test applying policies to validate resources."""
     cmd = kustomize.build(path)


### PR DESCRIPTION
Now for a git repo with two clusters and 11 kustomizations each and 30 helm repos each it's about 4-5x faster:
```
$ time flux-local get cluster -o yaml
real	0m1.922s
user	0m7.288s
sys	0m0.864s
```
```
$ time flux-local get hr -A
real	0m1.868s
user	0m6.430s
sys	0m0.843s
```