### PR TITLE
Performance improvements to flux-local get and diff

### DIFF
--- a/flux_local/tool/diff.py
+++ b/flux_local/tool/diff.py
@@ -103,10 +103,7 @@ class ResourceContentOutput:
 
     def call(self, ks: Kustomization, content: str | None) -> None:
         """Visitor function invoked to record build output."""
-        _LOGGER.debug(self.key_func(ks))
         if content:
-            _LOGGER.debug(len(content))
-            _LOGGER.debug(len(content.split("\n")))
             self.content[self.key_func(ks)] = content.split("\n") if content else []
 
     def key_func(self, ks: Kustomization) -> str:

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -1,8 +1,10 @@
 """Tests for git_repo."""
 
 from pathlib import Path
+import io
+from typing import Any
 
-from flux_local.git_repo import build_manifest, ResourceSelector
+from flux_local.git_repo import build_manifest, ResourceSelector, ResourceVisitor
 
 TESTDATA = Path("tests/testdata/cluster")
 
@@ -64,3 +66,34 @@ async def test_helm_release_selector_disabled() -> None:
     assert len(cluster.kustomizations) == 3
     assert len(cluster.helm_repos) == 0
     assert len(cluster.helm_releases) == 0
+
+
+async def test_kustomization_build() -> None:
+    """Tests for building the manifest."""
+
+    query = ResourceSelector()
+    query.path.path = TESTDATA
+
+    stream = io.StringIO()
+
+    def write(x: Any, y: str | None = None) -> None:
+        stream.write(y or "")
+
+    query.kustomization.visitor = ResourceVisitor(content=True, func=write)
+
+    manifest = await build_manifest(selector=query)
+    assert len(manifest.clusters) == 1
+    cluster = manifest.clusters[0]
+    assert cluster.name == "flux-system"
+    assert cluster.namespace == "flux-system"
+    assert cluster.path == "./tests/testdata/cluster/clusters/prod"
+    assert len(cluster.kustomizations) == 3
+    kustomization = cluster.kustomizations[0]
+    assert kustomization.name == "apps"
+    assert kustomization.namespace == "flux-system"
+    assert kustomization.path == "./tests/testdata/cluster/apps/prod"
+
+    content = stream.getvalue()
+    assert content
+    assert "kind: HelmRelease" in content
+    assert "name: metallb" in content

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -23,6 +23,24 @@ async def test_build_manifest() -> None:
     assert len(cluster.helm_releases) == 2
 
 
+async def test_build_manifest_ks_path() -> None:
+    """Tests for building a kustomization directly."""
+
+    query = ResourceSelector()
+    query.path.path = TESTDATA / "apps/prod"
+    query.kustomization.namespace = None
+
+    manifest = await build_manifest(selector=query)
+    assert len(manifest.clusters) == 1
+    cluster = manifest.clusters[0]
+    assert cluster.name == ""
+    assert cluster.namespace == ""
+    assert cluster.path == ""
+    assert len(cluster.kustomizations) == 1
+    assert len(cluster.helm_repos) == 0
+    assert len(cluster.helm_releases) == 1
+
+
 async def test_cluster_selector_disabled() -> None:
     """Tests for building the manifest."""
 

--- a/tests/tool/testdata/get_ks_path.yaml
+++ b/tests/tool/testdata/get_ks_path.yaml
@@ -1,0 +1,10 @@
+args:
+- get
+- ks
+- --path
+- ./tests/testdata/cluster/clusters/prod
+stdout: |
+  NAME                 PATH                                                   HELMREPOS    RELEASES    
+  apps                 ./tests/testdata/cluster/apps/prod                     0            1           
+  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            1           
+  infra-configs        ./tests/testdata/cluster/infrastructure/configs        2            0           

--- a/tests/tool/testdata/get_ks_path_ks.yaml
+++ b/tests/tool/testdata/get_ks_path_ks.yaml
@@ -1,0 +1,9 @@
+args:
+- get
+- ks
+- --all-namespaces
+- --path
+- ./tests/testdata/cluster/apps/prod
+stdout: |
+  NAME    PATH                                HELMREPOS    RELEASES    
+          tests/testdata/cluster/apps/prod    0            1           


### PR DESCRIPTION
Speed up flux-local get and diff by:
- Running build and grep commands in parallel
- Reusing build output with a visitor object to preserve build contents

Introduces a `ResourceVisitor` which can get invoked with the content of the build. The `git_repo` build logic is refactored into an async method that can run tasks in parallel and itself be parallelized.
