### PR TITLE
Fluxtomize resources without a kustomization present

### DIFF
--- a/flux_local/kustomize.py
+++ b/flux_local/kustomize.py
@@ -34,13 +34,17 @@ for object in objects:
 You can apply kyverno policies to the objects with the `validate` method.
 """
 
+import aiofiles
+from aiofiles.os import listdir  # type: ignore[attr-defined]
+from aiofiles.ospath import isdir, exists
+import asyncio
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
 import yaml
 
 from . import manifest
-from .command import Command, run_piped, Task
+from .command import Command, run_piped, Task, CommandException
 
 __all__ = [
     "build",
@@ -51,6 +55,7 @@ __all__ = [
 KUSTOMIZE_BIN = "kustomize"
 KYVERNO_BIN = "kyverno"
 HELM_RELEASE_KIND = "HelmRelease"
+KUSTOMIZE_FILES = ["kustomization.yaml", "kustomization.yml", "Kustomization"]
 
 
 class Kustomize:
@@ -146,6 +151,14 @@ class Build(Task):
         """Run the task."""
         if stdin is not None:
             raise ValueError("Invalid stdin cannot be passed to build command")
+
+        if not await isdir(self._path):
+            raise CommandException(f"Specified path is not a directory: {self._path}")
+        if not await can_kustomize_dir(self._path):
+            # Attempt to effectively generate a kustomization.yaml on the fly
+            # mirroring the behavior of flux
+            return await fluxtomize(self._path)
+
         args = [KUSTOMIZE_BIN, "build"]
         cwd: Path | None = None
         if self._path.is_absolute():
@@ -154,6 +167,50 @@ class Build(Task):
             args.append(str(self._path))
         task = Command(args, cwd=cwd)
         return await task.run()
+
+
+async def can_kustomize_dir(path: Path) -> bool:
+    """Return true if a kustomize file exists for the specified directory."""
+    for name in KUSTOMIZE_FILES:
+        if await exists(path / name):
+            return True
+    return False
+
+
+async def yaml_load_all(path: Path) -> list[dict[str, Any]]:
+    """Load all documents from the file."""
+    async with aiofiles.open(path) as f:
+        contents = await f.read()
+        return list(yaml.load_all(contents, Loader=yaml.Loader))
+
+
+async def fluxtomize(path: Path) -> bytes:
+    """Create a synthentic Kustomization file and attempt to build it.
+
+    This matches the behavior of flux, which kustomize does not support.
+    """
+
+    # TODO: Convert out of bytes to str
+
+    # Every file resource is read and output
+    # Every directory is kustomized
+    tasks = []
+    filenames = await listdir(path)
+    for filename in filenames:
+        new_path = path / filename
+        if new_path.is_dir() and await can_kustomize_dir(new_path):
+            tasks.append(build(new_path).objects())
+        elif filename.endswith(".yaml") or filename.endswith(".yml"):
+            tasks.append(yaml_load_all(new_path))
+        else:
+            continue
+
+    results = await asyncio.gather(*tasks)
+    docs = []
+    for result in results:
+        docs.extend(result)
+    out = yaml.dump_all(docs, sort_keys=False, explicit_start=True)
+    return str(out).encode("utf-8")
 
 
 def build(path: Path) -> Kustomize:

--- a/tests/testdata/cluster2/apps/kustomization.yaml
+++ b/tests/testdata/cluster2/apps/kustomization.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- monitoring
-- networking


### PR DESCRIPTION
Flux allows automatically creating a `kustomization.yaml` on the fly when there isn't one. This replicates that behavior by:
- including yaml files directly in the output
- Running `kustomize build` on subdirectories that do have a kustomziation file

Introduce a new task abstraction to allow piping data between tasks that are not just command line outputs. The fluxtomization does the equivalent work of a kustomize build but in a mix of python and cli, and the new abstraction allows us to put it at the start of the chain.

The testdata file in cluster2/apps that was removed was previously added as a stopgap and now it is no longer needed, matching the original layout of the cluster.

Issue #78 