### PR TITLE
Flux diff flags for configuring output (skip secrets, num context lines)

### DIFF
--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -31,6 +31,7 @@ KUSTOMIZE_DOMAIN = "kustomize.config.k8s.io"
 HELM_REPO_DOMAIN = "source.toolkit.fluxcd.io"
 HELM_RELEASE_DOMAIN = "helm.toolkit.fluxcd.io"
 CRD_KIND = "CustomResourceDefinition"
+SECRET_KIND = "Secret"
 
 
 def _check_version(doc: dict[str, Any], version: str) -> None:

--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -21,6 +21,7 @@ class BuildAction:
         path: pathlib.Path,
         enable_helm: bool,
         skip_crds: bool,
+        skip_secrets: bool,
         **kwargs,  # pylint: disable=unused-argument
     ) -> None:
         """Async Action implementation."""
@@ -41,7 +42,10 @@ class BuildAction:
         if enable_helm:
             with tempfile.TemporaryDirectory() as helm_cache_dir:
                 await helm_visitor.inflate(
-                    pathlib.Path(helm_cache_dir), content.visitor(), skip_crds
+                    pathlib.Path(helm_cache_dir),
+                    content.visitor(),
+                    skip_crds,
+                    skip_secrets,
                 )
 
         keys = list(content.content)

--- a/flux_local/tool/flux_local.py
+++ b/flux_local/tool/flux_local.py
@@ -50,6 +50,13 @@ def main() -> None:
         action=argparse.BooleanOptionalAction,
         help="Allows disabling of outputting CRDs to reduce output size",
     )
+    build_args.add_argument(
+        "--skip-secrets",
+        type=bool,
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Omit secrets from the output to reduce random output.",
+    )
     build_args.set_defaults(cls=build.BuildAction)
 
     get.GetAction.register(subparsers)

--- a/tests/tool/testdata/build_helm.yaml
+++ b/tests/tool/testdata/build_helm.yaml
@@ -187,20 +187,6 @@ stdout: |+
       internal.config.kubernetes.io/index: '1'
   automountServiceAccountToken: true
   ---
-  # Source: metallb/templates/controller/webhooks.yaml
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: webhook-server-cert
-    labels:
-      app.kubernetes.io/name: metallb
-      helm.sh/chart: metallb-4.1.14
-      app.kubernetes.io/instance: metallb
-      app.kubernetes.io/managed-by: Helm
-    annotations:
-      config.kubernetes.io/index: '2'
-      internal.config.kubernetes.io/index: '2'
-  ---
   # Source: metallb/templates/controller/configmap.yaml
   apiVersion: v1
   kind: ConfigMap


### PR DESCRIPTION
Add flags to control skip secret before, enabled by default. Add flags for controlling the number of output lines in the unified diff.