### PR TITLE
Change visitor API to async to support future features

### DIFF
--- a/flux_local/tool/visitor.py
+++ b/flux_local/tool/visitor.py
@@ -40,9 +40,9 @@ class ResourceContentOutput:
 
     def visitor(self) -> git_repo.ResourceVisitor:
         """Return a git_repo.ResourceVisitor that points to this object."""
-        return git_repo.ResourceVisitor(content=True, func=self.call)
+        return git_repo.ResourceVisitor(content=True, func=self.call_async)
 
-    def call(
+    async def call_async(
         self, path: pathlib.Path, doc: Kustomization | HelmRelease, content: str | None
     ) -> None:
         """Visitor function invoked to record build output."""
@@ -70,7 +70,7 @@ async def inflate_release(
 ) -> None:
     cmd = await helm.template(release, skip_crds=skip_crds, skip_secrets=skip_secrets)
     content = await cmd.run()
-    visitor.func(cluster_path, release, content)
+    await visitor.func(cluster_path, release, content)
 
 
 class HelmVisitor:
@@ -96,7 +96,7 @@ class HelmVisitor:
     def repo_visitor(self) -> git_repo.ResourceVisitor:
         """Return a git_repo.ResourceVisitor that points to this object."""
 
-        def add_repo(
+        async def add_repo(
             path: pathlib.Path, doc: HelmRepository, content: str | None
         ) -> None:
             self.repos[str(path)] = self.repos.get(str(path), []) + [doc]
@@ -106,7 +106,7 @@ class HelmVisitor:
     def release_visitor(self) -> git_repo.ResourceVisitor:
         """Return a git_repo.ResourceVisitor that points to this object."""
 
-        def add_release(
+        async def add_release(
             path: pathlib.Path, doc: HelmRelease, content: str | None
         ) -> None:
             self.releases[str(path)] = self.releases.get(str(path), []) + [doc]

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -122,7 +122,7 @@ async def test_kustomization_visitor() -> None:
 
     stream = io.StringIO()
 
-    def write(x: Path, y: Any, z: str | None = None) -> None:
+    async def write(x: Path, y: Any, z: str | None = None) -> None:
         stream.write(z or "")
 
     query.kustomization.visitor = ResourceVisitor(content=True, func=write)
@@ -153,8 +153,12 @@ async def test_helm_repo_visitor() -> None:
 
     objects: list[HelmRepository] = []
 
+    async def append(x: Path, y: Any, z: str | None = None) -> None:
+        objects.append(y)
+
     query.helm_repo.visitor = ResourceVisitor(
-        content=True, func=lambda x, y, z: objects.append(y)
+        content=True,
+        func=append,
     )
 
     manifest = await build_manifest(selector=query)
@@ -184,8 +188,12 @@ async def test_helm_release_visitor() -> None:
 
     objects: list[HelmRelease] = []
 
+    async def append(x: Path, y: Any, z: str | None = None) -> None:
+        objects.append(y)
+
     query.helm_release.visitor = ResourceVisitor(
-        content=True, func=lambda x, y, z: objects.append(y)
+        content=True,
+        func=append,
     )
 
     manifest = await build_manifest(selector=query)


### PR DESCRIPTION
Update the visitor API to be async so that we can add more functionality into it, such as combing the helm inflation in the kustomization inflation APIs.

Issue #90