### PR TITLE
Update structured output based on experience using in CI

### DIFF
--- a/flux_local/tool/diff.py
+++ b/flux_local/tool/diff.py
@@ -78,6 +78,8 @@ def perform_yaml_diff(
             diff_text = difflib.unified_diff(
                 a=a_resources.get(resource_key, []),
                 b=b_resources.get(resource_key, []),
+                fromfile=f"{kustomization_key.label} {resource_key.label}",
+                tofile=f"{kustomization_key.label} {resource_key.label}",
                 n=n,
             )
             diff_content = "\n".join(diff_text)
@@ -85,10 +87,7 @@ def perform_yaml_diff(
                 continue
             obj = {
                 **asdict(resource_key, dict_factory=omit_none),
-                "diff_markdown": f"""{resource_key.kind} {resource_key.namespace}/{resource_key.name}
-```diff
-{diff_content}
-```""",  # noqa: E501
+                "diff": diff_content,
             }
             resource_diffs.append(obj)
         if resource_diffs:

--- a/flux_local/tool/visitor.py
+++ b/flux_local/tool/visitor.py
@@ -39,9 +39,9 @@ class ResourceKey:
         parts = []
         if self.path:
             parts.append(self.path)
-            parts.append(" - ")
+            parts.append(" ")
         parts.append(self.kind)
-        parts.append("=")
+        parts.append(": ")
         if self.namespace:
             parts.append(self.namespace)
             parts.append("/")

--- a/tests/tool/test_diff.py
+++ b/tests/tool/test_diff.py
@@ -51,9 +51,9 @@ async def test_diff_ks() -> None:
 
     assert (
         result
-        == """--- tests/testdata/cluster/apps/prod - Kustomization=flux-system/apps ConfigMap=podinfo/podinfo-config
+        == """--- tests/testdata/cluster/apps/prod Kustomization: flux-system/apps ConfigMap: podinfo/podinfo-config
 
-+++ tests/testdata/cluster/apps/prod - Kustomization=flux-system/apps ConfigMap=podinfo/podinfo-config
++++ tests/testdata/cluster/apps/prod Kustomization: flux-system/apps ConfigMap: podinfo/podinfo-config
 
 @@ -1,9 +0,0 @@
 


### PR DESCRIPTION
Update the formatting based on experience trying to use the old format in CI. This reverts the markdown change, just putting the file information in the diff.