### PR TITLE
Improve diff helm performance by only templating on kustomization diffs

### DIFF
--- a/flux_local/tool/visitor.py
+++ b/flux_local/tool/visitor.py
@@ -274,13 +274,13 @@ class HelmVisitor:
         skip_secrets: bool,
     ) -> None:
         _LOGGER.debug("Inflating Helm charts in cluster %s", cluster_path)
-        active_repos = self.active_repos(str(cluster_path))
-        if not active_repos:
+        if not self.releases:
             return
         with tempfile.TemporaryDirectory() as tmp_dir:
             helm = Helm(pathlib.Path(tmp_dir), helm_cache_dir)
-            helm.add_repos(active_repos)
-            await helm.update()
+            if active_repos := self.active_repos(str(cluster_path)):
+                helm.add_repos(active_repos)
+                await helm.update()
             tasks = [
                 inflate_release(
                     cluster_path, helm, release, visitor, skip_crds, skip_secrets

--- a/tests/tool/testdata/build_helm.yaml
+++ b/tests/tool/testdata/build_helm.yaml
@@ -61,6 +61,181 @@ stdout: |+
         tag: 7.0.6
 
   ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+  kind: Kustomization
+  metadata:
+    name: apps
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    interval: 10m0s
+    dependsOn:
+    - name: infra-configs
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+    path: ./tests/testdata/cluster/apps/prod
+    prune: true
+    wait: true
+    timeout: 5m0s
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+  kind: Kustomization
+  metadata:
+    name: flux-system
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    interval: 10m0s
+    path: ./tests/testdata/cluster/clusters/prod
+    prune: true
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta1
+  kind: GitRepository
+  metadata:
+    name: flux-system
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    interval: 1m0s
+    ref:
+      branch: main
+    secretRef:
+      name: flux-system
+    url: ssh://git@github.com/allenporter/flux-local
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+  kind: Kustomization
+  metadata:
+    name: infra-controllers
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    interval: 1h
+    retryInterval: 1m
+    timeout: 5m
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+    path: ./tests/testdata/cluster/infrastructure/controllers
+    prune: true
+    wait: true
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+  kind: Kustomization
+  metadata:
+    name: infra-configs
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    dependsOn:
+    - name: infra-controllers
+    interval: 1h
+    retryInterval: 1m
+    timeout: 5m
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+    path: ./tests/testdata/cluster/infrastructure/configs
+    prune: true
+
+  ---
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    annotations:
+      policies.kyverno.io/description: Policy that is expected to allow resources under test through since no resources should have this annotation.
+      policies.kyverno.io/title: Test Allow Policy
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+    name: test-allow-policy
+  spec:
+    background: true
+    rules:
+    - match:
+        resources:
+          kinds:
+          - ConfigMap
+      name: forbid-test-annotation
+      validate:
+        message: Found test-annotation
+        pattern:
+          metadata:
+            =(annotations):
+              X(flux-local/test-annotation): "null"
+    validationFailureAction: audit
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    name: bitnami
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    interval: 30m
+    provider: generic
+    timeout: 1m0s
+    url: https://charts.bitnami.com/bitnami
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    name: podinfo
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    interval: 5m
+    url: https://stefanprodan.github.io/podinfo
+
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    name: metallb
+    namespace: metallb
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    chart:
+      spec:
+        chart: metallb
+        reconcileStrategy: ChartVersion
+        sourceRef:
+          kind: HelmRepository
+          name: bitnami
+          namespace: flux-system
+        version: 4.1.14
+    install:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+    interval: 5m
+    releaseName: metallb
+    upgrade:
+      crds: CreateReplace
+    values:
+      speaker:
+        secretName: metallb-secret
+
+  ---
   # Source: metallb/templates/controller/serviceaccount.yaml
   apiVersion: v1
   kind: ServiceAccount
@@ -1226,180 +1401,5 @@ stdout: |+
               name: podinfo
               port:
                 number: 9898
-
-  ---
-  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-  kind: Kustomization
-  metadata:
-    name: apps
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '0'
-      internal.config.kubernetes.io/index: '0'
-  spec:
-    interval: 10m0s
-    dependsOn:
-    - name: infra-configs
-    sourceRef:
-      kind: GitRepository
-      name: flux-system
-    path: ./tests/testdata/cluster/apps/prod
-    prune: true
-    wait: true
-    timeout: 5m0s
-  ---
-  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-  kind: Kustomization
-  metadata:
-    name: flux-system
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '1'
-      internal.config.kubernetes.io/index: '1'
-  spec:
-    interval: 10m0s
-    path: ./tests/testdata/cluster/clusters/prod
-    prune: true
-    sourceRef:
-      kind: GitRepository
-      name: flux-system
-  ---
-  apiVersion: source.toolkit.fluxcd.io/v1beta1
-  kind: GitRepository
-  metadata:
-    name: flux-system
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '2'
-      internal.config.kubernetes.io/index: '2'
-  spec:
-    interval: 1m0s
-    ref:
-      branch: main
-    secretRef:
-      name: flux-system
-    url: ssh://git@github.com/allenporter/flux-local
-  ---
-  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-  kind: Kustomization
-  metadata:
-    name: infra-controllers
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '3'
-      internal.config.kubernetes.io/index: '3'
-  spec:
-    interval: 1h
-    retryInterval: 1m
-    timeout: 5m
-    sourceRef:
-      kind: GitRepository
-      name: flux-system
-    path: ./tests/testdata/cluster/infrastructure/controllers
-    prune: true
-    wait: true
-  ---
-  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-  kind: Kustomization
-  metadata:
-    name: infra-configs
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '4'
-      internal.config.kubernetes.io/index: '4'
-  spec:
-    dependsOn:
-    - name: infra-controllers
-    interval: 1h
-    retryInterval: 1m
-    timeout: 5m
-    sourceRef:
-      kind: GitRepository
-      name: flux-system
-    path: ./tests/testdata/cluster/infrastructure/configs
-    prune: true
-
-  ---
-  apiVersion: kyverno.io/v1
-  kind: ClusterPolicy
-  metadata:
-    annotations:
-      policies.kyverno.io/description: Policy that is expected to allow resources under test through since no resources should have this annotation.
-      policies.kyverno.io/title: Test Allow Policy
-      config.kubernetes.io/index: '0'
-      internal.config.kubernetes.io/index: '0'
-    name: test-allow-policy
-  spec:
-    background: true
-    rules:
-    - match:
-        resources:
-          kinds:
-          - ConfigMap
-      name: forbid-test-annotation
-      validate:
-        message: Found test-annotation
-        pattern:
-          metadata:
-            =(annotations):
-              X(flux-local/test-annotation): "null"
-    validationFailureAction: audit
-  ---
-  apiVersion: source.toolkit.fluxcd.io/v1beta2
-  kind: HelmRepository
-  metadata:
-    name: bitnami
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '1'
-      internal.config.kubernetes.io/index: '1'
-  spec:
-    interval: 30m
-    provider: generic
-    timeout: 1m0s
-    url: https://charts.bitnami.com/bitnami
-  ---
-  apiVersion: source.toolkit.fluxcd.io/v1beta2
-  kind: HelmRepository
-  metadata:
-    name: podinfo
-    namespace: flux-system
-    annotations:
-      config.kubernetes.io/index: '2'
-      internal.config.kubernetes.io/index: '2'
-  spec:
-    interval: 5m
-    url: https://stefanprodan.github.io/podinfo
-
-  ---
-  apiVersion: helm.toolkit.fluxcd.io/v2beta1
-  kind: HelmRelease
-  metadata:
-    name: metallb
-    namespace: metallb
-    annotations:
-      config.kubernetes.io/index: '0'
-      internal.config.kubernetes.io/index: '0'
-  spec:
-    chart:
-      spec:
-        chart: metallb
-        reconcileStrategy: ChartVersion
-        sourceRef:
-          kind: HelmRepository
-          name: bitnami
-          namespace: flux-system
-        version: 4.1.14
-    install:
-      crds: CreateReplace
-      remediation:
-        retries: 3
-    interval: 5m
-    releaseName: metallb
-    upgrade:
-      crds: CreateReplace
-    values:
-      speaker:
-        secretName: metallb-secret
 
 ...


### PR DESCRIPTION
For my cluster with ~20 Kustomizations, 40 HelmRepos, and 50 HelmReleases, this means a single diff takes 26 seconds to compute where it used to take around 2 minutes.

This includes a breaking change to the visitor API to pass both the cluster and kustomization path rather than changing depending on the context.

Issue #89