### PR TITLE
Improve multiline string output for all diffs

### DIFF
--- a/flux_local/tool/diff.py
+++ b/flux_local/tool/diff.py
@@ -57,17 +57,6 @@ def perform_yaml_diff(
 ) -> Generator[str, None, None]:
     """Generate diffs between the two output objects."""
 
-    def str_presenter(dumper: yaml.Dumper, data: Any) -> Any:
-        """Represent multi-line yaml strings as you'd expect.
-
-        See https://github.com/yaml/pyyaml/issues/240
-        """
-        return dumper.represent_scalar(
-            "tag:yaml.org,2002:str", data, style="|" if data.count("\n") > 0 else None
-        )
-
-    yaml.add_representer(str, str_presenter)
-
     diffs = []
     for kustomization_key in set(a.content.keys()) | set(b.content.keys()):
         _LOGGER.debug("Diffing results for %s (n=%d)", kustomization_key, n)

--- a/flux_local/tool/flux_local.py
+++ b/flux_local/tool/flux_local.py
@@ -6,6 +6,7 @@ import logging
 import pathlib
 import sys
 import traceback
+from typing import Any
 
 import yaml
 
@@ -17,6 +18,18 @@ _LOGGER = logging.getLogger(__name__)
 
 def main() -> None:
     """Flux-local command line tool main entry point."""
+
+    def str_presenter(dumper: yaml.Dumper, data: Any) -> Any:
+        """Represent multi-line yaml strings as you'd expect.
+
+        See https://github.com/yaml/pyyaml/issues/240
+        """
+        return dumper.represent_scalar(
+            "tag:yaml.org,2002:str", data, style="|" if data.count("\n") > 0 else None
+        )
+
+    yaml.add_representer(str, str_presenter)
+
     # https://github.com/yaml/pyyaml/issues/89
     yaml.Loader.yaml_implicit_resolvers.pop("=")
 


### PR DESCRIPTION
Improve multiline string output for all diffs when they are in the middle of an object. Previously this logic was only applied to the final output, not intermediate diffs.