### PR TITLE
Do not expand help releases on get ks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use the flux command on a real cluster.
 
 This example lists all Kustomizations in the cluster:
 ```bash
-$ flux-local get ks
+$ flux-local get ks -o wide
 NAME                 PATH                                                   HELMREPOS    RELEASES
 apps                 ./tests/testdata/cluster/apps/prod                     0            0
 infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            0

--- a/tests/tool/testdata/get_ks.yaml
+++ b/tests/tool/testdata/get_ks.yaml
@@ -4,8 +4,8 @@ args:
 - --path
 - tests/testdata/cluster
 stdout: |
-  NAME                 PATH                                                   HELMREPOS    RELEASES    
-  apps                 ./tests/testdata/cluster/apps/prod                     0            1           
-  flux-system          ./tests/testdata/cluster/clusters/prod                 0            0           
-  infra-configs        ./tests/testdata/cluster/infrastructure/configs        2            0           
-  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            1           
+  NAME                 PATH                                                   
+  apps                 ./tests/testdata/cluster/apps/prod                     
+  flux-system          ./tests/testdata/cluster/clusters/prod                 
+  infra-configs        ./tests/testdata/cluster/infrastructure/configs        
+  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    

--- a/tests/tool/testdata/get_ks2.yaml
+++ b/tests/tool/testdata/get_ks2.yaml
@@ -4,9 +4,9 @@ args:
 - --path
 - tests/testdata/cluster2
 stdout: |
-  NAME                                       PATH                                                                    HELMREPOS    RELEASES    
-  cluster-apps                               ./tests/testdata/cluster2/apps                                          0            0           
-  cluster-apps-kubernetes-dashboard          ./tests/testdata/cluster2/apps/monitoring/kubernetes-dashboard/app      0            1           
-  cluster-apps-ingress-nginx                 ./tests/testdata/cluster2/apps/networking/ingress-nginx/app             0            1           
-  cluster-apps-ingress-nginx-certificates    ./tests/testdata/cluster2/apps/networking/ingress-nginx/certificates    0            0           
-  cluster                                    ./tests/testdata/cluster2/flux                                          3            0           
+  NAME                                       PATH                                                                    
+  cluster-apps                               ./tests/testdata/cluster2/apps                                          
+  cluster-apps-kubernetes-dashboard          ./tests/testdata/cluster2/apps/monitoring/kubernetes-dashboard/app      
+  cluster-apps-ingress-nginx                 ./tests/testdata/cluster2/apps/networking/ingress-nginx/app             
+  cluster-apps-ingress-nginx-certificates    ./tests/testdata/cluster2/apps/networking/ingress-nginx/certificates    
+  cluster                                    ./tests/testdata/cluster2/flux                                          

--- a/tests/tool/testdata/get_ks_path.yaml
+++ b/tests/tool/testdata/get_ks_path.yaml
@@ -4,8 +4,8 @@ args:
 - --path
 - ./tests/testdata/cluster/clusters/prod
 stdout: |
-  NAME                 PATH                                                   HELMREPOS    RELEASES    
-  apps                 ./tests/testdata/cluster/apps/prod                     0            1           
-  flux-system          ./tests/testdata/cluster/clusters/prod                 0            0           
-  infra-configs        ./tests/testdata/cluster/infrastructure/configs        2            0           
-  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            1           
+  NAME                 PATH                                                   
+  apps                 ./tests/testdata/cluster/apps/prod                     
+  flux-system          ./tests/testdata/cluster/clusters/prod                 
+  infra-configs        ./tests/testdata/cluster/infrastructure/configs        
+  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    

--- a/tests/tool/testdata/get_ks_path_ks.yaml
+++ b/tests/tool/testdata/get_ks_path_ks.yaml
@@ -5,5 +5,5 @@ args:
 - --path
 - ./tests/testdata/cluster/apps/prod
 stdout: |
-  NAME             PATH                                HELMREPOS    RELEASES    
-  kustomization    tests/testdata/cluster/apps/prod    0            1           
+  NAME             PATH                                
+  kustomization    tests/testdata/cluster/apps/prod    

--- a/tests/tool/testdata/get_ks_wide.yaml
+++ b/tests/tool/testdata/get_ks_wide.yaml
@@ -1,0 +1,13 @@
+args:
+- get
+- ks
+- -o
+- wide
+- --path
+- tests/testdata/cluster
+stdout: |
+  NAME                 PATH                                                   HELMREPOS    RELEASES    
+  apps                 ./tests/testdata/cluster/apps/prod                     0            1           
+  flux-system          ./tests/testdata/cluster/clusters/prod                 0            0           
+  infra-configs        ./tests/testdata/cluster/infrastructure/configs        2            0           
+  infra-controllers    ./tests/testdata/cluster/infrastructure/controllers    0            1           


### PR DESCRIPTION
Update the `flux get ks` command to have a flag `-o wide` that will generate Helm stats, hiding them by default.

```
$ time flux-local get ks -o wide
...
real	0m4.173s
user	0m9.874s
sys	0m1.155s
```

```
$ time flux-local get ks
...
real	0m0.570s
user	0m0.533s
sys	0m0.084s
````