### PR TITLE
Add ClusterPolicy objects to manifest

### DIFF
--- a/flux_local/kustomize.py
+++ b/flux_local/kustomize.py
@@ -149,8 +149,19 @@ class Kustomize:
         chaining with multiple branches.
         """
         content = await self.run()
-        tmp_file.write_text(content)
-        return Kustomize([Command(["cat", str(tmp_file)])])
+        return Kustomize([Stash(content.encode("utf-8"))])
+
+
+class Stash(Task):
+    """A task that memoizes output from a previous command."""
+
+    def __init__(self, out: bytes) -> None:
+        """Initialize Stash."""
+        self._out = out
+
+    async def run(self, stdin: bytes | None = None) -> bytes:
+        """Run the task."""
+        return self._out
 
 
 class Build(Task):

--- a/tests/tool/testdata/get_cluster_yaml.yaml
+++ b/tests/tool/testdata/get_cluster_yaml.yaml
@@ -23,11 +23,13 @@ stdout: |
           name: podinfo
           repo_name: podinfo
           repo_namespace: flux-system
+      cluster_policies: []
     - name: flux-system
       namespace: flux-system
       path: ./tests/testdata/cluster/clusters/prod
       helm_repos: []
       helm_releases: []
+      cluster_policies: []
     - name: infra-configs
       namespace: flux-system
       path: ./tests/testdata/cluster/infrastructure/configs
@@ -39,6 +41,9 @@ stdout: |
         namespace: flux-system
         url: https://stefanprodan.github.io/podinfo
       helm_releases: []
+      cluster_policies:
+      - name: test-allow-policy
+        namespace: null
     - name: infra-controllers
       namespace: flux-system
       path: ./tests/testdata/cluster/infrastructure/controllers
@@ -50,3 +55,4 @@ stdout: |
           name: metallb
           repo_name: bitnami
           repo_namespace: flux-system
+      cluster_policies: []


### PR DESCRIPTION
Add ClusterPolicy objects to manifest for Issue #43 
Contains multiple performance improvements since we're adding another object type to fetch, so now filtering will happen with fewer commands.