### PR TITLE
Add support for testing kyverno policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,12 @@ collected 18 items
 ============================================= 18 passed in 11.81s ============================================
 ```
 
-You may also validate `HelmRelease` objects can be templated properly with the `--enable-helm` flag. This
-will run `kustomize build` then run `helm template` on all the `HelmRelease` objects found:
+You may also validate `HelmRelease` objects can be templated properly with the `--enable-helm`
+flag. This will run `kustomize build` then run `helm template` on all the `HelmRelease` objects
+found. Additionally the `--enable-kyverno` flag will apply any found `ClusterPolicy` objects to
+all objects in the cluster and verify they pass:
 ```
-$ flux-local test --enable-helm
+$ flux-local test --enable-helm --enable-kyverno
 ============================================= test session starts =============================================
 collected 81 items
 

--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -208,8 +208,8 @@ class ClusterPolicy(BaseManifest):
     namespace: str | None = None
     """The namespace of the kustomization."""
 
-    spec: dict[str, Any]
-    """The contents of the policy."""
+    doc: dict[str, Any] | None = None
+    """The raw ClusterPolicy document."""
 
     @classmethod
     def parse_doc(cls, doc: dict[str, Any]) -> "ClusterPolicy":
@@ -220,12 +220,12 @@ class ClusterPolicy(BaseManifest):
         if not (name := metadata.get("name")):
             raise InputException(f"Invalid {cls} missing metadata.name: {doc}")
         namespace = metadata.get("namespace")
-        if not (spec := doc.get("spec")):
+        if not doc.get("spec"):
             raise InputException(f"Invalid {cls} missing spec: {doc}")
-        return ClusterPolicy(name=name, namespace=namespace, spec=spec)
+        return ClusterPolicy(name=name, namespace=namespace, doc=doc)
 
     _COMPACT_EXCLUDE_FIELDS = {
-        "spec": True,
+        "doc": True,
     }
 
 
@@ -352,7 +352,7 @@ class Cluster(BaseManifest):
         ]
 
     @property
-    def cluster_policieis(self) -> list[ClusterPolicy]:
+    def cluster_policies(self) -> list[ClusterPolicy]:
         """Return the list of ClusterPolicy objects from all Kustomizations."""
         return [
             policy

--- a/tests/test_kustomize.py
+++ b/tests/test_kustomize.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from flux_local import command, kustomize
+from flux_local import kustomize, exceptions
 
 TESTDATA_DIR = Path("tests/testdata")
 
@@ -69,9 +69,9 @@ async def test_objects(path: Path) -> None:
     "path",
     [TESTDATA_DIR / "repo", (TESTDATA_DIR / "repo").absolute()],
 )
-async def test_stash(path: Path, tmp_path: Path) -> None:
+async def test_stash(path: Path) -> None:
     """Test loading yaml documents."""
-    cmd = await kustomize.build(path).stash(tmp_path / "stash")
+    cmd = await kustomize.build(path).stash()
     result = await cmd.grep("kind=ConfigMap").objects()
     assert len(result) == 1
     assert result[0].get("kind") == "ConfigMap"
@@ -102,7 +102,7 @@ async def test_validate_fail(path: Path) -> None:
     """Test applying policies to validate resources."""
     cmd = kustomize.build(path)
     with pytest.raises(
-        command.CommandException, match="require-test-annotation: validation error"
+        exceptions.CommandException, match="require-test-annotation: validation error"
     ):
         await cmd.validate(TESTDATA_DIR / "policies/fail.yaml")
 

--- a/tests/tool/testdata/test_hr_policy.yaml
+++ b/tests/tool/testdata/test_hr_policy.yaml
@@ -1,0 +1,5 @@
+args:
+- test
+- --enable-helm
+- --enable-kyverno
+- tests/testdata/


### PR DESCRIPTION
Add kyverno policy checking e.g. 
```
flux-local test --enable-helm --enable-kyverno
```
Includes a breaking change for the `Kustomize.stash()` call.

Issue #43