### PR TITLE
Fix flux test bug: Ensure test path argument is optional

### DIFF
--- a/flux_local/tool/test.py
+++ b/flux_local/tool/test.py
@@ -347,6 +347,7 @@ class TestAction:
             help="Optional path with flux Kustomization resources or full test node",
             type=str,
             default=None,
+            nargs="?",
         )
         verbosity_group = args.add_mutually_exclusive_group()
         verbosity_group.add_argument(


### PR DESCRIPTION
This was previously broken in https://github.com/allenporter/flux-local/pull/115