### PR TITLE
Resolve the process and root paths when comparing

### DIFF
--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -137,7 +137,7 @@ class PathSelector:
         """
         if not self.process_path.is_absolute():
             return self.process_path
-        return self.process_path.relative_to(self.root)
+        return self.process_path.resolve().relative_to(self.root.resolve())
 
     @property
     def process_path(self) -> Path:


### PR DESCRIPTION
Resolve the process and root paths when comparing so that any sym links will be resolved. This allows paths to be compared against each other so we can determine the relative path to process within the repo.

Fixes Issue #119