### PR TITLE
Remove stale reference to flake8

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,6 +33,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
         ruff check --format=github .


### PR DESCRIPTION
Update ruff configuration to match rules in https://github.com/allenporter/repo-conformance