### PR TITLE
Print errors to stderr instead of stout

### DIFF
--- a/flux_local/tool/flux_local.py
+++ b/flux_local/tool/flux_local.py
@@ -86,8 +86,8 @@ def main() -> None:
         asyncio.run(action.run(**vars(args)))
     except FluxException as err:
         if args.log_level == "DEBUG":
-            traceback.print_exc()
-        print("flux-local error: ", err)
+            traceback.print_exc(file=sys.stderr)
+        print("flux-local error: ", err, file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
so that they are still visible if you redirect stdout to a file (e.g. for capturing diff output)