### PR TITLE
Add support for HelmRepository type oci

### DIFF
--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -36,6 +36,9 @@ CLUSTER_POLICY_DOMAIN = "kyverno.io"
 CRD_KIND = "CustomResourceDefinition"
 SECRET_KIND = "Secret"
 
+REPO_TYPE_DEFAULT = "default"
+REPO_TYPE_OCI = "oci"
+
 
 def _check_version(doc: dict[str, Any], version: str) -> None:
     """Assert that the resource has the specified version."""
@@ -199,7 +202,12 @@ class HelmRepository(BaseManifest):
             raise InputException(f"Invalid {cls} missing spec: {doc}")
         if not (url := spec.get("url")):
             raise InputException(f"Invalid {cls} missing spec.url: {doc}")
-        return cls(name=name, namespace=namespace, url=url, repo_type=spec.get("type"))
+        return cls(
+            name=name,
+            namespace=namespace,
+            url=url,
+            repo_type=spec.get("type", REPO_TYPE_DEFAULT),
+        )
 
     @property
     def repo_name(self) -> str:

--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -159,6 +159,11 @@ class HelmRelease(BaseManifest):
         """Identifier for the HelmRelease."""
         return f"{self.namespace}-{self.name}"
 
+    @property
+    def repo_name(self) -> str:
+        """Identifier for the HelmRepository identified in the HelmChart."""
+        return f"{self.chart.repo_namespace}-{self.chart.repo_name}"
+
     _COMPACT_EXCLUDE_FIELDS = {
         "values": True,
         "chart": HelmChart._COMPACT_EXCLUDE_FIELDS,
@@ -177,6 +182,9 @@ class HelmRepository(BaseManifest):
     url: str
     """The URL to the repository of helm charts."""
 
+    repo_type: str | None = None
+    """The type of the HelmRepository."""
+
     @classmethod
     def parse_doc(cls, doc: dict[str, Any]) -> "HelmRepository":
         """Parse a HelmRepository from a kubernetes resource."""
@@ -191,7 +199,7 @@ class HelmRepository(BaseManifest):
             raise InputException(f"Invalid {cls} missing spec: {doc}")
         if not (url := spec.get("url")):
             raise InputException(f"Invalid {cls} missing spec.url: {doc}")
-        return cls(name=name, namespace=namespace, url=url)
+        return cls(name=name, namespace=namespace, url=url, repo_type=spec.get("type"))
 
     @property
     def repo_name(self) -> str:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -71,7 +71,7 @@ def test_parse_helm_repository() -> None:
     assert repo.name == "bitnami"
     assert repo.namespace == "flux-system"
     assert repo.url == "https://charts.bitnami.com/bitnami"
-    assert not repo.repo_type
+    assert repo.repo_type == "default"
     repo = HelmRepository.parse_doc(docs[1])
     assert repo.name == "podinfo"
     assert repo.namespace == "flux-system"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -60,14 +60,23 @@ def test_compact_helm_release() -> None:
 def test_parse_helm_repository() -> None:
     """Test parsing a helm repository doc."""
 
-    docs = yaml.load_all(
-        (TESTDATA_DIR / "configs/helm-repositories.yaml").read_text(),
-        Loader=yaml.CLoader,
+    docs = list(
+        yaml.load_all(
+            (TESTDATA_DIR / "configs/helm-repositories.yaml").read_text(),
+            Loader=yaml.CLoader,
+        )
     )
-    repo = HelmRepository.parse_doc(next(iter(docs)))
+    assert len(docs) == 2
+    repo = HelmRepository.parse_doc(docs[0])
     assert repo.name == "bitnami"
     assert repo.namespace == "flux-system"
     assert repo.url == "https://charts.bitnami.com/bitnami"
+    assert not repo.repo_type
+    repo = HelmRepository.parse_doc(docs[1])
+    assert repo.name == "podinfo"
+    assert repo.namespace == "flux-system"
+    assert repo.url == "oci://ghcr.io/stefanprodan/charts"
+    assert repo.repo_type == "oci"
 
 
 async def test_write_manifest_file() -> None:

--- a/tests/testdata/cluster/infrastructure/configs/helm-repositories.yaml
+++ b/tests/testdata/cluster/infrastructure/configs/helm-repositories.yaml
@@ -17,4 +17,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  url: https://stefanprodan.github.io/podinfo
+  type: oci
+  url: oci://ghcr.io/stefanprodan/charts

--- a/tests/tool/testdata/build.yaml
+++ b/tests/tool/testdata/build.yaml
@@ -200,7 +200,8 @@ stdout: |+
       internal.config.kubernetes.io/index: '2'
   spec:
     interval: 5m
-    url: https://stefanprodan.github.io/podinfo
+    type: oci
+    url: oci://ghcr.io/stefanprodan/charts
 
   ---
   apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/tests/tool/testdata/build_helm.yaml
+++ b/tests/tool/testdata/build_helm.yaml
@@ -202,7 +202,8 @@ stdout: |+
       internal.config.kubernetes.io/index: '2'
   spec:
     interval: 5m
-    url: https://stefanprodan.github.io/podinfo
+    type: oci
+    url: oci://ghcr.io/stefanprodan/charts
 
   ---
   apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/tests/tool/testdata/get_cluster_yaml.yaml
+++ b/tests/tool/testdata/get_cluster_yaml.yaml
@@ -37,9 +37,11 @@ stdout: |
       - name: bitnami
         namespace: flux-system
         url: https://charts.bitnami.com/bitnami
+        repo_type: default
       - name: podinfo
         namespace: flux-system
-        url: https://stefanprodan.github.io/podinfo
+        url: oci://ghcr.io/stefanprodan/charts
+        repo_type: oci
       helm_releases: []
       cluster_policies:
       - name: test-allow-policy


### PR DESCRIPTION
Add support for HelmRepository type oci.

See https://fluxcd.io/blog/2022/11/verify-the-integrity-of-the-helm-charts-stored-as-oci-artifacts-before-reconciling-them-with-flux/ for an example on how to set up.

This was added following the pattern in https://github.com/onedr0p/home-ops/commit/5ca73a5e518a8610fb408a70db5e2839bbdfe125