### PR TITLE
Skip 'chart' and 'app.kubernetes.io/version' labels

### DIFF
--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: '3.10'
   strip-attrs:
     description: Labels and annotations that should be stripped to reduce diff noise
-    default: helm.sh/chart,checksum/config
+    default: helm.sh/chart,checksum/config,app.kubernetes.io/version,chart
   debug:
     description: When true, uses the DEBUG log level
     default: false


### PR DESCRIPTION
Strip these additional labels found on kube-prometheus-stack charts, e.g. https://github.com/allenporter/k8s-gitops/pull/1143#issuecomment-1565340720

Issue #203