### PR TITLE
Refactor build cli command line flags

### DIFF
--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -1,8 +1,14 @@
 """Flux-local build action."""
 
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction as SubParsersAction,
+    BooleanOptionalAction,
+)
 import logging
 import pathlib
 import tempfile
+from typing import cast
 
 
 from flux_local import git_repo
@@ -16,6 +22,33 @@ _LOGGER = logging.getLogger(__name__)
 
 class BuildAction:
     """Flux-local build action."""
+
+    @classmethod
+    def register(
+        cls, subparsers: SubParsersAction  # type: ignore[type-arg]
+    ) -> ArgumentParser:
+        """Register the subparser commands."""
+        args = cast(
+            ArgumentParser,
+            subparsers.add_parser(
+                "build",
+                help="Build local flux Kustomization target from a local directory",
+            ),
+        )
+        args.add_argument(
+            "path", type=pathlib.Path, help="Path to the kustomization or charts"
+        )
+        args.add_argument(
+            "--enable-helm",
+            type=bool,
+            action=BooleanOptionalAction,
+            help="Enable use of HelmRelease inflation",
+        )
+        # pylint: disable=duplicate-code
+        selector.add_common_flags(args)
+        selector.add_helm_options_flags(args)
+        args.set_defaults(cls=cls)
+        return args
 
     async def run(  # type: ignore[no-untyped-def]
         self,

--- a/flux_local/tool/diff.py
+++ b/flux_local/tool/diff.py
@@ -3,8 +3,7 @@
 import asyncio
 import functools
 import os
-from argparse import ArgumentParser
-from argparse import _SubParsersAction as SubParsersAction
+from argparse import ArgumentParser, _SubParsersAction as SubParsersAction
 from contextlib import contextmanager
 from dataclasses import asdict
 import difflib

--- a/flux_local/tool/flux_local.py
+++ b/flux_local/tool/flux_local.py
@@ -3,14 +3,13 @@
 import argparse
 import asyncio
 import logging
-import pathlib
 import sys
 import traceback
 from typing import Any
 
 import yaml
 
-from . import build, diff, get, test, selector
+from . import build, diff, get, test
 from flux_local.exceptions import FluxException
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,43 +41,7 @@ def main() -> None:
 
     subparsers = parser.add_subparsers(dest="command", help="Command", required=True)
 
-    build_args = subparsers.add_parser(
-        "build",
-        help="Build local flux Kustomization target from a local directory",
-    )
-    build_args.add_argument(
-        "path", type=pathlib.Path, help="Path to the kustomization or charts"
-    )
-    build_args.add_argument(
-        "--enable-helm",
-        type=bool,
-        action=argparse.BooleanOptionalAction,
-        help="Enable use of HelmRelease inflation",
-    )
-    # pylint: disable=duplicate-code
-    build_args.add_argument(
-        "--skip-crds",
-        type=bool,
-        default=False,
-        action=argparse.BooleanOptionalAction,
-        help="Allows disabling of outputting CRDs to reduce output size",
-    )
-    build_args.add_argument(
-        "--skip-secrets",
-        type=bool,
-        default=True,
-        action=argparse.BooleanOptionalAction,
-        help="Omit secrets from the output to reduce random output.",
-    )
-    build_args.add_argument(
-        "--kustomize-build-flags",
-        type=str,
-        default="",
-        help="If present, additional flags to pass to `kustomize build`",
-    )
-    selector.add_helm_options_flags(build_args)
-    build_args.set_defaults(cls=build.BuildAction)
-
+    build.BuildAction.register(subparsers)
     get.GetAction.register(subparsers)
     diff.DiffAction.register(subparsers)
     test.TestAction.register(subparsers)

--- a/flux_local/tool/get.py
+++ b/flux_local/tool/get.py
@@ -1,8 +1,7 @@
 """Flux-local get action."""
 
 import logging
-from argparse import ArgumentParser
-from argparse import _SubParsersAction as SubParsersAction
+from argparse import ArgumentParser, _SubParsersAction as SubParsersAction
 from typing import cast, Any
 
 from flux_local import git_repo

--- a/flux_local/tool/selector.py
+++ b/flux_local/tool/selector.py
@@ -70,6 +70,11 @@ def add_selector_flags(args: ArgumentParser) -> None:
         default=DEFAULT_NAMESPACE,
         help="If present, the namespace scope for this request",
     )
+    add_common_flags(args)
+
+
+def add_common_flags(args: ArgumentParser) -> None:
+    """Add flags that are common to selectors and other command types."""
     args.add_argument(
         "--skip-crds",
         type=str,

--- a/flux_local/tool/test.py
+++ b/flux_local/tool/test.py
@@ -1,7 +1,10 @@
 """Flux local test action."""
 
-from argparse import ArgumentParser, BooleanOptionalAction
-from argparse import _SubParsersAction as SubParsersAction
+from argparse import (
+    ArgumentParser,
+    BooleanOptionalAction,
+    _SubParsersAction as SubParsersAction,
+)
 import asyncio
 from dataclasses import dataclass
 import logging


### PR DESCRIPTION
Update build to use the same pattern as other tools, and share some of the command flags with other selector based commands.