### PR TITLE
Change default kustomize build behavior to match flux

### DIFF
--- a/flux_local/kustomize.py
+++ b/flux_local/kustomize.py
@@ -66,6 +66,11 @@ KYVERNO_BIN = "kyverno"
 HELM_RELEASE_KIND = "HelmRelease"
 KUSTOMIZE_FILES = ["kustomization.yaml", "kustomization.yml", "Kustomization"]
 
+# Use the same behavior as flux to allow loading files outside the directory
+# containing kustomization.yaml
+# https://fluxcd.io/flux/faq/#what-is-the-behavior-of-kustomize-used-by-flux
+KUSTOMIZE_BUILD_FLAGS = ["--load-restrictor=LoadRestrictionsNone"]
+
 
 class Kustomize:
     """Library for issuing a kustomize command."""
@@ -190,7 +195,9 @@ class Build(Task):
     def __init__(self, path: Path, kustomize_flags: list[str] | None = None) -> None:
         """Initialize Build."""
         self._path = path
-        self._kustomize_flags = kustomize_flags or []
+        self._kustomize_flags = list(KUSTOMIZE_BUILD_FLAGS)
+        if kustomize_flags:
+            self._kustomize_flags.extend(kustomize_flags)
 
     async def run(self, stdin: bytes | None = None) -> bytes:
         """Run the task."""

--- a/tests/test_kustomize.py
+++ b/tests/test_kustomize.py
@@ -175,3 +175,15 @@ async def test_fluxtomize_ignores_empty_subdir(tmp_path: Path) -> None:
 
     content = await kustomize.fluxtomize(tmp_path)
     assert not content
+
+
+async def test_build_flags() -> None:
+    """Test a kustomize build command with extra flags."""
+    result = await kustomize.build(
+        TESTDATA_DIR / "repo",
+        # Duplicates existing flags, should be a no-op
+        kustomize_flags=["--load-restrictor=LoadRestrictionsNone"],
+    ).run()
+    assert "Secret" in result
+    assert "ConfigMap" in result
+    assert result == (TESTDATA_DIR / "repo/all.golden").read_text()


### PR DESCRIPTION
Follow the same flags as set by flux https://fluxcd.io/flux/faq/#what-is-the-behavior-of-kustomize-used-by-flux to have similar `kustomize build` behavior.