### PR TITLE
Add a `diagnostics` command to find yaml files that kustomize does no…

### DIFF
--- a/flux_local/tool/diagnostics.py
+++ b/flux_local/tool/diagnostics.py
@@ -1,0 +1,62 @@
+"""Command line tool for diagnosing configuration problems in the cluster."""
+
+import logging
+from argparse import ArgumentParser, _SubParsersAction as SubParsersAction
+from typing import cast
+import os
+import pathlib
+import yaml
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DiagnosticsAction:
+    """Flux-local diagnostics action."""
+
+    @classmethod
+    def register(
+        cls, subparsers: SubParsersAction  # type: ignore[type-arg]
+    ) -> ArgumentParser:
+        """Register the subparser commands."""
+        args = cast(
+            ArgumentParser,
+            subparsers.add_parser(
+                "diagnostics",
+                help="Print information about local flux that can diagnose issues",
+                description="Print information about the local cluster to aid with diagnosing problems.",
+            ),
+        )
+        args.add_argument(
+            "--path",
+            help="Optional path with flux Kustomization resources (multi-cluster ok)",
+            type=pathlib.Path,
+            default=None,
+            nargs="?",
+        )
+        args.set_defaults(cls=cls)
+        return args
+
+    async def run(  # type: ignore[no-untyped-def]
+        self,
+        **kwargs,  # pylint: disable=unused-argument
+    ) -> None:
+        """Async Action implementation."""
+        path = kwargs.get("path") or "."
+
+        for root, dirs, files in os.walk(str(path)):
+            for file in files:
+                if not (file.endswith(".yaml") or file.endswith(".yml")):
+                    continue
+                full_path = pathlib.Path(root) / file
+                try:
+                    doc = list(yaml.safe_load_all(full_path.read_text()))
+                except yaml.YAMLError as err:
+                    print(f"Filed `{full_path}` failed to parse as yaml: {err}")
+
+                for subdoc in doc:
+                    if isinstance(subdoc, dict):
+                        continue
+                    print(
+                        f"File `{full_path}` is not a yaml dictionary: {type(subdoc)}: {subdoc}"
+                    )

--- a/flux_local/tool/flux_local.py
+++ b/flux_local/tool/flux_local.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import yaml
 
-from . import build, diff, get, test
+from . import build, diff, get, test, diagnostics
 from flux_local.exceptions import FluxException
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,6 +29,7 @@ def _make_parser() -> argparse.ArgumentParser:
     get.GetAction.register(subparsers)
     diff.DiffAction.register(subparsers)
     test.TestAction.register(subparsers)
+    diagnostics.DiagnosticsAction.register(subparsers)
     return parser
 
 

--- a/tests/tool/__snapshots__/test_diagnostics.ambr
+++ b/tests/tool/__snapshots__/test_diagnostics.ambr
@@ -1,0 +1,20 @@
+# serializer version: 1
+# name: test_diagnostics
+  '''
+  [DIAGNOSTICS FAIL]: `example.yaml` expected dictionary but was list: ['foo']
+  
+  '''
+# ---
+# name: test_invalid_mapping[list]
+  '''
+  [DIAGNOSTICS FAIL]: `<<TEST_FILE>>` expected dictionary but was list: ['entry']
+  
+  '''
+# ---
+# name: test_invalid_mapping[scalar]
+  '''
+  [DIAGNOSTICS FAIL]: `<<TEST_FILE>>` was not a dictionary: <class 'str'>: entry
+  [DIAGNOSTICS FAIL]: `<<TEST_FILE>>` was not a dictionary: <class 'str'>: var
+  
+  '''
+# ---

--- a/tests/tool/__snapshots__/test_diagnostics.ambr
+++ b/tests/tool/__snapshots__/test_diagnostics.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_diagnostics
   '''
-  [DIAGNOSTICS FAIL]: `example.yaml` expected dictionary but was list: ['foo']
+  [DIAGNOSTICS OK]
   
   '''
 # ---

--- a/tests/tool/__snapshots__/test_diagnostics.ambr
+++ b/tests/tool/__snapshots__/test_diagnostics.ambr
@@ -11,6 +11,13 @@
   
   '''
 # ---
+# name: test_invalid_mapping[not-yaml]
+  '''
+  [DIAGNOSTICS FAIL]: `<<TEST_FILE>>` failed to parse as yaml: unacceptable character #x0000: special characters are not allowed
+    in "<unicode string>", position 0
+  
+  '''
+# ---
 # name: test_invalid_mapping[scalar]
   '''
   [DIAGNOSTICS FAIL]: `<<TEST_FILE>>` was not a dictionary: <class 'str'>: entry

--- a/tests/tool/test_diagnostics.py
+++ b/tests/tool/test_diagnostics.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import tempfile
-from typing import Any
 
 from syrupy.assertion import SnapshotAssertion
 import yaml
@@ -18,20 +17,19 @@ async def test_diagnostics(snapshot: SnapshotAssertion) -> None:
 
 
 @pytest.mark.parametrize(
-    ("data"),
+    ("contents"),
     [
-        ([["entry"]]),
-        (["entry", "var"]),
+        (yaml.dump_all([["entry"]]).encode()),
+        (yaml.dump_all(["entry", "var"]).encode()),
+        (b"\x00\x00\x00"),
     ],
-    ids=["list", "scalar"],
+    ids=["list", "scalar", "not-yaml"],
 )
-async def test_invalid_mapping(data: Any, snapshot: SnapshotAssertion) -> None:
+async def test_invalid_mapping(contents: bytes, snapshot: SnapshotAssertion) -> None:
     """Test test get ks commands."""
     with tempfile.TemporaryDirectory() as tmp_dir:
-        contents = yaml.dump_all(data)
-
         example_file = pathlib.Path(tmp_dir) / "example.yaml"
-        example_file.write_text(contents)
+        example_file.write_bytes(contents)
 
         result = await run_command(["diagnostics", "--path", tmp_dir])
         result = result.replace(str(example_file), "<<TEST_FILE>>")

--- a/tests/tool/test_diagnostics.py
+++ b/tests/tool/test_diagnostics.py
@@ -1,0 +1,38 @@
+"""Tests for the flux-local `diagnostics` command."""
+
+import pathlib
+import tempfile
+from typing import Any
+
+from syrupy.assertion import SnapshotAssertion
+import yaml
+import pytest
+
+from . import run_command
+
+
+async def test_diagnostics(snapshot: SnapshotAssertion) -> None:
+    """Test test get ks commands."""
+    result = await run_command(["diagnostics"])
+    assert result == snapshot
+
+
+@pytest.mark.parametrize(
+    ("data"),
+    [
+        ([["entry"]]),
+        (["entry", "var"]),
+    ],
+    ids=["list", "scalar"],
+)
+async def test_invalid_mapping(data: Any, snapshot: SnapshotAssertion) -> None:
+    """Test test get ks commands."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        contents = yaml.dump_all(data)
+
+        example_file = pathlib.Path(tmp_dir) / "example.yaml"
+        example_file.write_text(contents)
+
+        result = await run_command(["diagnostics", "--path", tmp_dir])
+        result = result.replace(str(example_file), "<<TEST_FILE>>")
+        assert result == snapshot


### PR DESCRIPTION
Given an example yaml file that kustomize doesn't like:
 
```yaml
# cat ./example.yaml 
---
- example
```

The `diagnostics` command can identify it to help decide how to handle:
```
$ flux-local diagnostics
File `example.yaml` is not a yaml dictionary: <class 'list'>: ['example']
```