### PR TITLE
Improve error messages for shell commands

### DIFF
--- a/flux_local/command.py
+++ b/flux_local/command.py
@@ -96,7 +96,7 @@ class Command(Task):
                 errors.append(out.decode("utf-8"))
             if err:
                 errors.append(err.decode("utf-8"))
-            _LOGGER.error("\n".join(errors))
+            _LOGGER.debug("\n".join(errors))
             raise self.exc("\n".join(errors))
         return out
 

--- a/flux_local/exceptions.py
+++ b/flux_local/exceptions.py
@@ -23,6 +23,10 @@ class KustomizeException(CommandException):
     """Raised when there is a failure running a kustomize command."""
 
 
+class KustomizePathException(CommandException):
+    """Raised a Kustomization points to a path that does not exist."""
+
+
 class HelmException(CommandException):
     """Raised when there is a failure running a helm command."""
 

--- a/flux_local/kustomize.py
+++ b/flux_local/kustomize.py
@@ -48,6 +48,7 @@ from .exceptions import (
     InputException,
     KustomizeException,
     KyvernoException,
+    KustomizePathException,
 )
 from .manifest import Kustomization
 
@@ -201,7 +202,9 @@ class FluxBuild(Task):
         if stdin is not None:
             raise InputException("Invalid stdin cannot be passed to build command")
         if not await isdir(self._path):
-            raise InputException(f"Specified path is not a directory: {self._path}")
+            raise KustomizePathException(
+                f"Kustomization '{self._ks.namespaced_name}' path field '{self._ks.path or ''}' is not a directory: {self._path}"
+            )
 
         args = [
             FLUX_BIN,

--- a/flux_local/tool/test.py
+++ b/flux_local/tool/test.py
@@ -18,6 +18,7 @@ import nest_asyncio
 import pytest
 
 from flux_local import git_repo, kustomize
+from flux_local.exceptions import FluxException
 from flux_local.helm import Helm, Options
 from flux_local.manifest import (
     Manifest,
@@ -271,6 +272,7 @@ class ManifestPlugin:
         self.manifest: Manifest | None = None
         self.test_config = test_config
         self.test_filter = test_filter
+        self.init_error: Exception | None = None
 
     def pytest_sessionstart(self, session: pytest.Session) -> None:
         nest_asyncio.apply()
@@ -279,17 +281,25 @@ class ManifestPlugin:
     async def async_pytest_sessionstart(self, session: pytest.Session) -> None:
         """Run the Kustomizations test."""
         _LOGGER.debug("async_pytest_sessionstart")
-        manifest = await git_repo.build_manifest(
-            selector=self.selector,
-            options=self.test_config.options,
-        )
+        try:
+            manifest = await git_repo.build_manifest(
+                selector=self.selector,
+                options=self.test_config.options,
+            )
+        except FluxException as err:
+            _LOGGER.error("Failed to build manifest: %s", err)
+            self.init_error = err
+            return
+
         self.manifest = manifest
         _LOGGER.debug("async_pytest_sessionstart ended")
 
     def pytest_collection(self, session: pytest.Session) -> None:
         _LOGGER.debug("pytest_collection:%s", session)
-        if not self.manifest:
-            raise ValueError("ManifestPlugin not initialized properly")
+        if self.init_error or self.manifest is None:
+            raise pytest.UsageError(
+                self.init_error or "ManifestPlugin not initialized properly"
+            ) from self.init_error
         manifest_collector = ManifestCollector.from_parent(
             parent=session,
             manifest=self.manifest,


### PR DESCRIPTION
Improve error messages by catching the common messages, supressing unnecessary verbose logging when necessasary.