### PR TITLE
Fix support for Kustomizations with absolute paths

### DIFF
--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -345,7 +345,10 @@ def adjust_ks_path(doc: Kustomization, selector: PathSelector) -> Path | None:
         )
         return None
 
-    return Path(doc.path)
+    path = Path(doc.path)
+    if path.is_absolute():
+        return path.relative_to("/")
+    return path
 
 
 async def kustomization_traversal(selector: PathSelector) -> list[Kustomization]:

--- a/tests/testdata/cluster7/clusters/home/charts.yaml
+++ b/tests/testdata/cluster7/clusters/home/charts.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m0s
-  path: ./tests/testdata/cluster7/flux/charts
+  path: /tests/testdata/cluster7/flux/charts
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Add support for a Kustomization that refers to an absolute path. This will be treated as if it were relative to the root.

Fixes #407