### PR TITLE
Remove complexity from multi-cluster diff

### DIFF
--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -201,7 +201,6 @@ class ResourceVisitor:
     func: Callable[
         [
             Path,
-            Path,
             Kustomization | HelmRelease | HelmRepository | ClusterPolicy,
             kustomize.Kustomize | None,
         ],
@@ -546,7 +545,6 @@ async def build_kustomization(
 
         if kustomization_selector.visitor:
             await kustomization_selector.visitor.func(
-                cluster_path,
                 Path(kustomization.path),
                 kustomization,
                 cmd,
@@ -675,7 +673,6 @@ async def build_manifest(
                 for kustomization in cluster.kustomizations:
                     for helm_repo in kustomization.helm_repos:
                         await selector.helm_repo.visitor.func(
-                            Path(cluster.path),
                             Path(kustomization.path),
                             helm_repo,
                             None,
@@ -685,7 +682,6 @@ async def build_manifest(
                 for kustomization in cluster.kustomizations:
                     for helm_release in kustomization.helm_releases:
                         await selector.helm_release.visitor.func(
-                            Path(cluster.path),
                             Path(kustomization.path),
                             helm_release,
                             None,
@@ -695,7 +691,6 @@ async def build_manifest(
                 for kustomization in cluster.kustomizations:
                     for cluster_policy in kustomization.cluster_policies:
                         await selector.cluster_policy.visitor.func(
-                            Path(cluster.path),
                             Path(kustomization.path),
                             cluster_policy,
                             None,

--- a/tests/__snapshots__/test_git_repo.ambr
+++ b/tests/__snapshots__/test_git_repo.ambr
@@ -290,19 +290,16 @@
 # name: test_helm_release_visitor.1
   list([
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/apps/prod',
       'podinfo',
       'podinfo',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/controllers',
       'flux-system',
       'weave-gitops',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/controllers',
       'metallb',
       'metallb',
@@ -500,19 +497,16 @@
 # name: test_helm_repo_visitor.1
   list([
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/configs',
       'flux-system',
       'bitnami',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/configs',
       'flux-system',
       'podinfo',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/configs',
       'flux-system',
       'weave-charts',
@@ -980,25 +974,21 @@
 # name: test_kustomization_visitor.1
   list([
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/apps/prod',
       'flux-system',
       'apps',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/clusters/prod',
       'flux-system',
       'flux-system',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/configs',
       'flux-system',
       'infra-configs',
     ),
     tuple(
-      'tests/testdata/cluster',
       'tests/testdata/cluster/infrastructure/controllers',
       'flux-system',
       'infra-controllers',

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -87,8 +87,8 @@ async def test_kustomization_visitor(snapshot: SnapshotAssertion) -> None:
     stream = io.StringIO()
     visits: list[tuple[str, str, str, str]] = []
 
-    async def write(w: Path, x: Path, y: Any, cmd: Kustomize | None) -> None:
-        visits.append((str(w), str(x), y.namespace, y.name))
+    async def write(x: Path, y: Any, cmd: Kustomize | None) -> None:
+        visits.append((str(x), y.namespace, y.name))
         if cmd:
             stream.write(await cmd.run())
 
@@ -114,8 +114,8 @@ async def test_helm_repo_visitor(snapshot: SnapshotAssertion) -> None:
 
     visits: list[tuple[str, str, str, str]] = []
 
-    async def append(w: Path, x: Path, y: Any, z: Any) -> None:
-        visits.append((str(w), str(x), y.namespace, y.name))
+    async def append(x: Path, y: Any, z: Any) -> None:
+        visits.append((str(x), y.namespace, y.name))
 
     query.helm_repo.visitor = ResourceVisitor(func=append)
 
@@ -134,8 +134,8 @@ async def test_helm_release_visitor(snapshot: SnapshotAssertion) -> None:
 
     visits: list[tuple[str, str, str, str]] = []
 
-    async def append(w: Path, x: Path, y: Any, z: Any) -> None:
-        visits.append((str(w), str(x), y.namespace, y.name))
+    async def append(x: Path, y: Any, z: Any) -> None:
+        visits.append((str(x), y.namespace, y.name))
 
     query.helm_release.visitor = ResourceVisitor(
         func=append,

--- a/tests/tool/__snapshots__/test_diff_ks.ambr
+++ b/tests/tool/__snapshots__/test_diff_ks.ambr
@@ -8,14 +8,12 @@
 # name: test_diff_ks[yaml-empty-sources]
   '''
   ---
-  - cluster_path: tests/testdata/cluster
-    kustomization_path: tests/testdata/cluster/apps/prod
+  - kustomization_path: tests/testdata/cluster/apps/prod
     kind: Kustomization
     namespace: flux-system
     name: apps
     diffs:
-    - cluster_path: tests/testdata/cluster
-      kustomization_path: tests/testdata/cluster/apps/prod
+    - kustomization_path: tests/testdata/cluster/apps/prod
       kind: Namespace
       namespace: flux-system
       name: podinfo
@@ -35,8 +33,7 @@
         -    kustomize.toolkit.fluxcd.io/namespace: flux-system
         -  name: podinfo
         -
-    - cluster_path: tests/testdata/cluster
-      kustomization_path: tests/testdata/cluster/apps/prod
+    - kustomization_path: tests/testdata/cluster/apps/prod
       kind: HelmRelease
       namespace: podinfo
       name: podinfo
@@ -84,8 +81,7 @@
         -      repository: public.ecr.aws/docker/library/redis
         -      tag: 7.0.6
         -
-    - cluster_path: tests/testdata/cluster
-      kustomization_path: tests/testdata/cluster/apps/prod
+    - kustomization_path: tests/testdata/cluster/apps/prod
       kind: ConfigMap
       namespace: podinfo
       name: podinfo-config


### PR DESCRIPTION
Remove the unnecessary code from multi-cluster diff. Multi-cluster repos are still supported, just not with a single diff command.