### PR TITLE
Improve timeout error message

### DIFF
--- a/flux_local/command.py
+++ b/flux_local/command.py
@@ -106,7 +106,10 @@ async def _run_piped_with_sem(cmds: Sequence[Task]) -> str:
     stdin = None
     out = None
     for cmd in cmds:
-        out = await asyncio.wait_for(cmd.run(stdin), _TIMEOUT)
+        try:
+            out = await asyncio.wait_for(cmd.run(stdin), _TIMEOUT)
+        except asyncio.exceptions.TimeoutError as err:
+            raise cmd.exc(f"Command '{cmd}' timed out") from err
         stdin = out
     return out.decode("utf-8") if out else ""
 


### PR DESCRIPTION
Improve timeout error message when a subcommand fails to complete in time to show the actual command that was run.

Example:
```
FAILED tests/tool/test_test.py::test_test_hr[policy] - flux_local.exceptions.CommandException: Command 'flux-local test --enable-helm --enable-kyverno tests/testdata/cluster' timed out
```