### PR TITLE
Set cache dependency paths based on action

### DIFF
--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -59,6 +59,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
+        cache-dependency-path: ${{ github.action_path }}/../../requirements.txt
     - name: Install flux-local and requirements
       run: |
         pip install -r ${{ github.action_path }}/../../requirements.txt

--- a/action/test/action.yml
+++ b/action/test/action.yml
@@ -44,6 +44,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
+        cache-dependency-path: ${{ github.action_path }}/../../requirements.txt
     - name: Install flux-local and requirements
       run: |
         pip install -r ${{ github.action_path }}/../../requirements.txt


### PR DESCRIPTION
Fixes https://github.com/onedr0p/home-ops/actions/runs/7290504875/job/19867462979#step:14:42 where the pip cache was looking at the wrong requirements file.
```
Error: No file in /home/runner/work/home-ops/home-ops matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository
```

Issue #437