### PR TITLE
Add --output-file for build and diff and use in action

### DIFF
--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -82,11 +82,9 @@ runs:
       with:
         ref: ${{ inputs.live-branch }}
         path: live
-    - name: flux-local diff
+    - name: Diff Resources
       id: flux_diff
       run: |
-        delimiter="$(openssl rand -hex 8)"
-        echo "diff<<${delimiter}" >> $GITHUB_OUTPUT
         if [[ "${{ inputs.resource }}" == "helmrelease" ]]; then
           extra_flags="--api-versions=${{ inputs.api-versions}}"
         else
@@ -106,7 +104,13 @@ runs:
             --all-namespaces \
             --kustomize-build-flags="${{ inputs.kustomize-build-flags }}" \
             --sources "${{ inputs.sources }}" \
-            ${extra_flags} \
-            >> $GITHUB_OUTPUT
+            --output-file diff.patch \
+            ${extra_flags}
+    - name: Generate Diff output
+      id: flux_diff_output
+      run: |
+        delimiter="$(openssl rand -hex 8)"
+        echo "diff<<${delimiter}" >> $GITHUB_OUTPUT
+        cat diff.patch >> $GITHUB_OUTPUT
         echo "${delimiter}" >> $GITHUB_OUTPUT
       shell: bash

--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -106,6 +106,7 @@ runs:
             --sources "${{ inputs.sources }}" \
             --output-file diff.patch \
             ${extra_flags}
+      shell: bash
     - name: Generate Diff output
       id: flux_diff_output
       run: |

--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -47,6 +47,12 @@ class BuildAction:
             action=BooleanOptionalAction,
             help="Enable use of HelmRelease inflation",
         )
+        args.add_argument(
+            "--output-file",
+            type=str,
+            default="/dev/stdout",
+            help="Output file for the results of the command",
+        )
         # pylint: disable=duplicate-code
         selector.add_common_flags(args)
         selector.add_helm_options_flags(args)
@@ -59,6 +65,7 @@ class BuildAction:
         enable_helm: bool,
         skip_crds: bool,
         skip_secrets: bool,
+        output_file: str,
         **kwargs,  # pylint: disable=unused-argument
     ) -> None:
         """Async Action implementation."""
@@ -97,14 +104,15 @@ class BuildAction:
                     helm_options,
                 )
 
-        keys = list(content.content)
-        keys.sort()
-        for key in keys:
-            for line in content.content[key]:
-                print(line)
+        with open(kwargs["output_file"], "w") as output_file:
+            keys = list(content.content)
+            keys.sort()
+            for key in keys:
+                for line in content.content[key]:
+                    print(line, file=output_file)
 
-        keys = list(helm_content.content)
-        keys.sort()
-        for key in keys:
-            for line in helm_content.content[key]:
-                print(line)
+            keys = list(helm_content.content)
+            keys.sort()
+            for key in keys:
+                for line in helm_content.content[key]:
+                    print(line, file=output_file)

--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -104,15 +104,15 @@ class BuildAction:
                     helm_options,
                 )
 
-        with open(kwargs["output_file"], "w") as output_file:
+        with open(output_file, "w") as file:
             keys = list(content.content)
             keys.sort()
             for key in keys:
                 for line in content.content[key]:
-                    print(line, file=output_file)
+                    print(line, file=file)
 
             keys = list(helm_content.content)
             keys.sort()
             for key in keys:
                 for line in helm_content.content[key]:
-                    print(line, file=output_file)
+                    print(line, file=file)


### PR DESCRIPTION
Add the --output-file command for `diff` and `build`. Also update the diff action to use the output file command as in the example in the feature request.

Fixes #455