### PR TITLE
fix: change running user to 1001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ COPY --from=docker.io/bitnami/kubectl:1.28.5            /opt/bitnami/kubectl/bin
 COPY --from=registry.k8s.io/kustomize/kustomize:v5.3.0  /app/kustomize                   /usr/local/bin/kustomize
 COPY --from=ghcr.io/kyverno/kyverno-cli:v1.10.7         /ko-app/kubectl-kyverno          /usr/local/bin/kyverno
 
+USER 1001
 ENTRYPOINT ["/usr/local/bin/flux-local"]


### PR DESCRIPTION
Currently the container runs as root. This change is needed because of the following error when using the container in Github actions since Git will see the files as owned by 1001 instead of what the container expects of `root`

```
Traceback (most recent call last):
  File "/usr/local/bin/flux-local", line 33, in <module>
    sys.exit(load_entry_point('flux-local', 'console_scripts', 'flux-local')())
  File "/app/flux_local/tool/flux_local.py", line 61, in main
    asyncio.run(action.run(**vars(args)))
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/app/flux_local/tool/diff.py", line 278, in run
    await git_repo.build_manifest(
  File "/app/flux_local/git_repo.py", line 628, in build_manifest
    results = await kustomization_traversal(selector.path, builder)
  File "/app/flux_local/git_repo.py", line 471, in kustomization_traversal
    for result in await asyncio.gather(*tasks):
  File "/app/flux_local/git_repo.py", line 408, in visit_kustomization
    cmd = kustomize.grep(f"kind={CLUSTER_KUSTOMIZE_KIND}", selector.root / path)
  File "/app/flux_local/git_repo.py", line 179, in root
    return repo_root(self.repo)
  File "/app/flux_local/git_repo.py", line 142, in repo_root
    return Path(repo.git.rev_parse("--show-toplevel"))
  File "/usr/local/lib/python3.10/site-packages/git/cmd.py", line 736, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/git/cmd.py", line 1316, in _call_process
    return self.execute(call, **exec_kwargs)
  File "/usr/local/lib/python3.10/site-packages/git/cmd.py", line 1111, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git rev-parse --show-toplevel
  stderr: 'fatal: detected dubious ownership in repository at '/github/workspace/pr'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace/pr'
```