### PR TITLE
Honour --output-file when there are not Helm Releases

### DIFF
--- a/flux_local/tool/diff.py
+++ b/flux_local/tool/diff.py
@@ -375,7 +375,8 @@ class DiffHelmReleaseAction:
             )
 
         if not helm_visitor.releases and not orig_helm_visitor.releases:
-            print(selector.not_found("HelmRelease", query.helm_release))
+            with open(output_file, "w") as file:
+                print(selector.not_found("HelmRelease", query.helm_release), file=file)
             return
 
         # Find HelmRelease objects with diffs and prune all other HelmReleases from


### PR DESCRIPTION
Fix issue where diffs for no helm releases breaks the action output.