### PR TITLE
feat(action): allow to use a custom token for cloning the repository

### DIFF
--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -46,7 +46,6 @@ inputs:
   token:
     description: GitHub token to use for cloning the repository
     required: false
-    default: ''
 outputs:
   diff:
     description: Output of the diff command or empty if there is no diff
@@ -81,13 +80,13 @@ runs:
       uses: actions/checkout@v4
       with:
         path: pr
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token }} || ${{ github.token }}
     - name: Checkout live branch
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.live-branch }}
         path: live
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token }} || ${{ github.token }}
     - name: Diff Resources
       id: flux_diff
       run: |

--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -80,13 +80,13 @@ runs:
       uses: actions/checkout@v4
       with:
         path: pr
-        token: ${{ inputs.token }} || ${{ github.token }}
+        token: ${{ inputs.token || github.token }}
     - name: Checkout live branch
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.live-branch }}
         path: live
-        token: ${{ inputs.token }} || ${{ github.token }}
+        token: ${{ inputs.token || github.token }}
     - name: Diff Resources
       id: flux_diff
       run: |

--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -43,6 +43,10 @@ inputs:
   sources:
     description: GitRepository or OCIRepository to include with optional source mappings like `flux-system` or `cluster=./kubernetes/`
     default: ''
+  token:
+    description: GitHub token to use for cloning the repository
+    required: false
+    default: ''
 outputs:
   diff:
     description: Output of the diff command or empty if there is no diff
@@ -77,11 +81,13 @@ runs:
       uses: actions/checkout@v4
       with:
         path: pr
+        token: ${{ inputs.token }}
     - name: Checkout live branch
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.live-branch }}
         path: live
+        token: ${{ inputs.token }}
     - name: Diff Resources
       id: flux_diff
       run: |


### PR DESCRIPTION
Hi @allenporter,

I would like to add the option to pass a token for the checkout (this is required if the repository is not public)

The suggestion from @szinn in #353 does not seem to work, I have tested this one and it worked for me.