### PR TITLE
Use mashumaro for yaml parsing and drop pydantic

### DIFF
--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -6,7 +6,7 @@ e.g. such as writing management plan for resources.
 """
 
 import base64
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 import logging
 from pathlib import Path
 from typing import Any, Optional, cast

--- a/flux_local/tool/get.py
+++ b/flux_local/tool/get.py
@@ -75,7 +75,7 @@ class GetKustomizationAction:
             cols.insert(0, "cluster")
         for cluster in manifest.clusters:
             for ks in cluster.kustomizations:
-                value = ks.dict(include=set(cols))
+                value = { k: v for k, v in ks.compact_dict().items() if k in cols }
                 if output == "wide":
                     value["helmrepos"] = len(ks.helm_repos)
                     value["releases"] = len(ks.helm_releases)
@@ -126,7 +126,7 @@ class GetHelmReleaseAction:
         results: list[dict[str, Any]] = []
         for cluster in manifest.clusters:
             for helmrelease in cluster.helm_releases:
-                value = helmrelease.dict(include=set(cols))
+                value = { k: v for k, v in helmrelease.compact_dict().items() if k in cols }
                 value["revision"] = str(helmrelease.chart.version)
                 value["chart"] = f"{helmrelease.namespace}-{helmrelease.chart.name}"
                 value["source"] = helmrelease.chart.repo_name
@@ -230,7 +230,7 @@ class GetClusterAction:
         cols = ["path", "kustomizations"]
         results: list[dict[str, Any]] = []
         for cluster in manifest.clusters:
-            value: dict[str, Any] = cluster.dict(include=set(cols))
+            value = { k: v for k, v in cluster.compact_dict().items() if k in cols }
             value["kustomizations"] = len(cluster.kustomizations)
             results.append(value)
 

--- a/flux_local/values.py
+++ b/flux_local/values.py
@@ -225,7 +225,8 @@ def expand_value_references(
                 f"Error building HelmRelease '{helm_release.namespaced_name}': {err}"
             )
 
-    return helm_release.model_copy(update={"values": values})
+    helm_release.values = values
+    return helm_release
 
 
 def expand_postbuild_substitute_reference(

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-plugins = pydantic.mypy
 ignore_missing_imports = True
 exclude = (venv|build)
 check_untyped_defs = True
@@ -16,9 +15,3 @@ warn_unreachable = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_no_return = True
-
-[pydantic-mypy]
-init_forbid_extra = False
-init_typed = True
-warn_required_dynamic_aliases = True
-warn_untyped_fields = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ aiofiles==23.2.1
 black==24.4.0
 coverage==7.4.4
 GitPython==3.1.43
+mashumaro==3.12
 mypy==1.9.0
 nest_asyncio==1.6.0
 pdoc==14.4.0
 pip==24.0
 pre-commit==3.7.0
-pydantic==2.7.0
 pytest==8.1.1
 pytest-asyncio==0.23.6
 pytest-cov==5.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,10 +20,10 @@ python_requires = >=3.10
 install_requires =
   aiofiles>=22.1.0
   nest_asyncio>=1.5.6
-  pydantic>=2.5.2
   python-slugify>=8.0.0
   GitPython>=3.1.30
   PyYAML>=6.0
+  mashumaro>=3.12
   # Note: flux-local provides repo testing using pytest
   pytest>=7.2.1
   pytest-asyncio>=0.20.3

--- a/tests/test_kustomize.py
+++ b/tests/test_kustomize.py
@@ -124,7 +124,7 @@ async def test_target_namespace() -> None:
 async def test_flux_build_path_is_not_dir() -> None:
     """Test case where the flux build path does not exist."""
     cmd = kustomize.flux_build(
-        manifest.Kustomization(name="example", path="./"),
+        manifest.Kustomization(name="example", path="./", namespace="flux-system"),
         Path(TESTDATA_DIR) / "does-not-exist",
     )
     with pytest.raises(exceptions.FluxException, match="not a directory"):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -109,7 +109,7 @@ async def test_serializing_manifest(tmp_path: Path) -> None:
     )
     await write_manifest(tmp_path / "file.yaml", manifest)
     new_manifest = await read_manifest(tmp_path / "file.yaml")
-    assert new_manifest.model_dump() == {
+    assert new_manifest.compact_dict() == {
         "clusters": [
             {
                 "path": "./example",
@@ -117,5 +117,3 @@ async def test_serializing_manifest(tmp_path: Path) -> None:
             },
         ]
     }
-    assert new_manifest.compact_dict() == new_manifest.model_dump()
-    assert new_manifest.compact_dict() == manifest.model_dump()

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -55,16 +55,14 @@ def test_values_references_with_values_key() -> None:
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-values-configmap",
-                valuesKey="some-key",
-                targetPath="target.path",
+                values_key="some-key",
+                target_path="target.path",
             ),
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-binary-data-configmap",
-                valuesKey="some-key",
+                values_key="some-key",
             ),
         ],
     )
@@ -115,10 +113,9 @@ def test_values_references_with_missing_values_key() -> None:
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-values-configmap",
-                valuesKey="some-key-does-not-exist",
-                targetPath="target.path",
+                values_key="some-key-does-not-exist",
+                target_path="target.path",
             )
         ],
     )
@@ -156,7 +153,6 @@ def test_values_references_invalid_yaml() -> None:
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-values-configmap",
             )
         ],
@@ -193,7 +189,6 @@ def test_values_references_invalid_binary_data() -> None:
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-values-configmap",
             )
         ],
@@ -233,11 +228,10 @@ def test_values_reference_invalid_target_path() -> None:
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-values-configmap",
-                valuesKey="some-key",
+                values_key="some-key",
                 # Target above is a list
-                targetPath="target.path",
+                target_path="target.path",
             )
         ],
     )
@@ -273,19 +267,16 @@ def test_values_reference_invalid_configmap_and_secret() -> None:
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
-                namespace="test",
                 name="test-values-configmap",
                 optional=False,  # We just log
             ),
             ValuesReference(
                 kind="Secret",
-                namespace="test",
                 name="test-values-secret",
                 optional=False,  # We just log
             ),
             ValuesReference(
                 kind="UnknownKind",
-                namespace="test",
                 name="test-values-secret",
             ),
         ],
@@ -317,17 +308,15 @@ def test_values_references_secret() -> None:
         values_from=[
             ValuesReference(
                 kind="Secret",
-                namespace="test",
                 name="test-values-secret",
-                valuesKey="some-key1",
-                targetPath="target.path1",
+                values_key="some-key1",
+                target_path="target.path1",
             ),
             ValuesReference(
                 kind="Secret",
-                namespace="test",
                 name="test-string-values-secret",
-                valuesKey="some-key2",
-                targetPath="target.path2",
+                values_key="some-key2",
+                target_path="target.path2",
             ),
         ],
     )


### PR DESCRIPTION
Allows removing a lot of code, given mashumaro is simpler. pydantic also had a very odd upgrade strategy, and is growing too complex for use in this project.