### PR TITLE
feat: Parse HelmRelease with chartRef

### DIFF
--- a/flux_local/helm.py
+++ b/flux_local/helm.py
@@ -68,6 +68,8 @@ DEFAULT_REGISTRY_CONFIG = "/dev/null"
 
 def _chart_name(release: HelmRelease, repo: HelmRepository | None) -> str:
     """Return the helm chart name used for the helm template command."""
+    if not release.chart:
+        raise HelmException(f"HelmRelease {release.name} has no chart")
     if release.chart.repo_kind == HELM_REPOSITORY:
         if repo and repo.repo_type == REPO_TYPE_OCI:
             return f"{repo.url}/{release.chart.name}"
@@ -210,6 +212,8 @@ class Helm:
 
         The values will come from the `HelmRelease` object.
         """
+        if not release.chart:
+            raise HelmException(f"HelmRelease {release.name} has no chart")
         if options is None:
             options = Options()
         repo = next(

--- a/flux_local/tool/get.py
+++ b/flux_local/tool/get.py
@@ -127,6 +127,9 @@ class GetHelmReleaseAction:
         for cluster in manifest.clusters:
             for helmrelease in cluster.helm_releases:
                 value = { k: v for k, v in helmrelease.compact_dict().items() if k in cols }
+                # TODO: Support resolving `chartRef` HelmRepository and OCIRepository.
+                if not helmrelease.chart:
+                    continue
                 value["revision"] = str(helmrelease.chart.version)
                 value["chart"] = f"{helmrelease.namespace}-{helmrelease.chart.name}"
                 value["source"] = helmrelease.chart.repo_name

--- a/flux_local/tool/test.py
+++ b/flux_local/tool/test.py
@@ -97,6 +97,8 @@ class HelmReleaseTest(pytest.Item):
 
     def active_repos(self) -> list[HelmRepository]:
         """Return HelpRepositories referenced by a HelmRelease."""
+        if not self.helm_release.chart:
+            return []
         repo_key = "-".join(
             [
                 self.helm_release.chart.repo_namespace,
@@ -181,13 +183,15 @@ class KustomizationCollector(pytest.Collector):
             test_config=self.test_config,
         )
         for helm_release in self.kustomization.helm_releases:
-            yield HelmReleaseTest.from_parent(
-                parent=self,
-                cluster=self.cluster,
-                kustomization=self.kustomization,
-                helm_release=helm_release,
-                test_config=self.test_config,
-            )
+            # TODO: Only HelmRelease with `chart` can be tested. `chartRef` is not supported.
+            if helm_release.chart:
+                yield HelmReleaseTest.from_parent(
+                    parent=self,
+                    cluster=self.cluster,
+                    kustomization=self.kustomization,
+                    helm_release=helm_release,
+                    test_config=self.test_config,
+                )
 
 
 class ClusterCollector(pytest.Collector):

--- a/tests/__snapshots__/test_git_repo.ambr
+++ b/tests/__snapshots__/test_git_repo.ambr
@@ -95,6 +95,15 @@
             ]),
             'helm_releases': list([
               dict({
+                'chart_ref': dict({
+                  'kind': 'OCIRepository',
+                  'name': 'kyverno',
+                  'namespace': 'flux-system',
+                }),
+                'name': 'kyverno',
+                'namespace': 'kyverno',
+              }),
+              dict({
                 'chart': dict({
                   'name': 'metallb',
                   'repo_kind': 'HelmRepository',
@@ -331,6 +340,15 @@
             ]),
             'helm_releases': list([
               dict({
+                'chart_ref': dict({
+                  'kind': 'OCIRepository',
+                  'name': 'kyverno',
+                  'namespace': 'flux-system',
+                }),
+                'name': 'kyverno',
+                'namespace': 'kyverno',
+              }),
+              dict({
                 'chart': dict({
                   'name': 'metallb',
                   'repo_kind': 'HelmRepository',
@@ -376,6 +394,11 @@
       'tests/testdata/cluster/infrastructure/controllers',
       'flux-system',
       'weave-gitops',
+    ),
+    tuple(
+      'tests/testdata/cluster/infrastructure/controllers',
+      'kyverno',
+      'kyverno',
     ),
     tuple(
       'tests/testdata/cluster/infrastructure/controllers',
@@ -461,6 +484,15 @@
             'config_maps': list([
             ]),
             'helm_releases': list([
+              dict({
+                'chart_ref': dict({
+                  'kind': 'OCIRepository',
+                  'name': 'kyverno',
+                  'namespace': 'flux-system',
+                }),
+                'name': 'kyverno',
+                'namespace': 'kyverno',
+              }),
               dict({
                 'chart': dict({
                   'name': 'metallb',
@@ -591,6 +623,15 @@
             'config_maps': list([
             ]),
             'helm_releases': list([
+              dict({
+                'chart_ref': dict({
+                  'kind': 'OCIRepository',
+                  'name': 'kyverno',
+                  'namespace': 'flux-system',
+                }),
+                'name': 'kyverno',
+                'namespace': 'kyverno',
+              }),
               dict({
                 'chart': dict({
                   'name': 'metallb',
@@ -1123,6 +1164,15 @@
             'config_maps': list([
             ]),
             'helm_releases': list([
+              dict({
+                'chart_ref': dict({
+                  'kind': 'OCIRepository',
+                  'name': 'kyverno',
+                  'namespace': 'flux-system',
+                }),
+                'name': 'kyverno',
+                'namespace': 'kyverno',
+              }),
               dict({
                 'chart': dict({
                   'name': 'metallb',

--- a/tests/test_helm.py
+++ b/tests/test_helm.py
@@ -59,8 +59,9 @@ async def test_template(helm: Helm, helm_releases: list[dict[str, Any]]) -> None
     """Test helm template command."""
     await helm.update()
 
-    assert len(helm_releases) == 2
-    release = helm_releases[0]
+    assert len(helm_releases) == 3
+    # metallb release, see tests/testdata/cluster/infrastructure/controllers/kustomization.yaml
+    release = helm_releases[1]
     obj = await helm.template(HelmRelease.parse_doc(release))
     docs = await obj.grep("kind=ServiceAccount").objects()
     names = [doc.get("metadata", {}).get("name") for doc in docs]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -28,6 +28,7 @@ def test_parse_helm_release() -> None:
     )
     assert release.name == "metallb"
     assert release.namespace == "metallb"
+    assert release.chart is not None
     assert release.chart.name == "metallb"
     assert release.chart.version == "4.1.14"
     assert release.chart.repo_name == "bitnami"

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -54,6 +54,7 @@ def test_values_references_with_values_key() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -112,6 +113,7 @@ def test_values_references_with_missing_values_key() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -152,6 +154,7 @@ def test_values_references_with_missing_secret() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -188,6 +191,7 @@ def test_values_references_with_missing_secret_values_key() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -228,6 +232,7 @@ def test_values_references_invalid_yaml() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -264,6 +269,7 @@ def test_values_references_invalid_binary_data() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -304,6 +310,7 @@ def test_values_reference_invalid_target_path() -> None:
             "test": "test",
             "target": ["a", "b", "c"],
         },
+        chart_ref=None,
         values_from=[
             ValuesReference(
                 kind="ConfigMap",
@@ -342,6 +349,7 @@ def test_values_reference_invalid_configmap_and_secret() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(
@@ -383,6 +391,7 @@ def test_values_references_secret() -> None:
             name="test-chart",
             version="test-version",
         ),
+        chart_ref=None,
         values={"test": "test"},
         values_from=[
             ValuesReference(

--- a/tests/testdata/cluster/infrastructure/configs/kustomization.yaml
+++ b/tests/testdata/cluster/infrastructure/configs/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - cluster-policies.yaml
   - helm-repositories.yaml
+  - oci-repositories.yaml

--- a/tests/testdata/cluster/infrastructure/configs/oci-repositories.yaml
+++ b/tests/testdata/cluster/infrastructure/configs/oci-repositories.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: kyverno
+  namespace: flux-system
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+    operation: copy
+  url: oci://ghcr.io/kyverno/charts/kyverno
+  ref:
+    tag: 3.2.3
+    digest: sha256:d363081e45627aa396d6c8cb2d4ee59fcb7a79c223a967ae601c8c8ba4e7b7f3

--- a/tests/testdata/cluster/infrastructure/controllers/kustomization.yaml
+++ b/tests/testdata/cluster/infrastructure/controllers/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - kyverno-release.yaml
   - metallb-release.yaml
   - weave-gitops-release.yaml

--- a/tests/testdata/cluster/infrastructure/controllers/kyverno-release.yaml
+++ b/tests/testdata/cluster/infrastructure/controllers/kyverno-release.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+  namespace: kyverno
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: kyverno
+    namespace: flux-system
+  driftDetection:
+    mode: enabled
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3

--- a/tests/tool/__snapshots__/test_build.ambr
+++ b/tests/tool/__snapshots__/test_build.ambr
@@ -2988,7 +2988,56 @@
     interval: 120m
     type: oci
     url: oci://ghcr.io/weaveworks/charts
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: OCIRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-configs
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: kyverno
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    interval: 1h
+    layerSelector:
+      mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+      operation: copy
+    ref:
+      digest: sha256:d363081e45627aa396d6c8cb2d4ee59fcb7a79c223a967ae601c8c8ba4e7b7f3
+      tag: 3.2.3
+    url: oci://ghcr.io/kyverno/charts/kyverno
   
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-controllers
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: kyverno
+    namespace: kyverno
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    chartRef:
+      kind: OCIRepository
+      name: kyverno
+      namespace: flux-system
+    driftDetection:
+      mode: enabled
+    install:
+      remediation:
+        retries: 3
+    interval: 5m
+    upgrade:
+      cleanupOnFail: true
+      remediation:
+        retries: 3
+        strategy: rollback
   ---
   apiVersion: helm.toolkit.fluxcd.io/v2beta1
   kind: HelmRelease
@@ -2999,8 +3048,8 @@
     name: metallb
     namespace: metallb
     annotations:
-      config.kubernetes.io/index: '0'
-      internal.config.kubernetes.io/index: '0'
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
   spec:
     chart:
       spec:
@@ -3032,8 +3081,8 @@
     name: weave-gitops
     namespace: flux-system
     annotations:
-      config.kubernetes.io/index: '1'
-      internal.config.kubernetes.io/index: '1'
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
   spec:
     chart:
       spec:
@@ -4731,7 +4780,56 @@
     interval: 120m
     type: oci
     url: oci://ghcr.io/weaveworks/charts
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: OCIRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-configs
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: kyverno
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    interval: 1h
+    layerSelector:
+      mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+      operation: copy
+    ref:
+      digest: sha256:d363081e45627aa396d6c8cb2d4ee59fcb7a79c223a967ae601c8c8ba4e7b7f3
+      tag: 3.2.3
+    url: oci://ghcr.io/kyverno/charts/kyverno
   
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-controllers
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: kyverno
+    namespace: kyverno
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    chartRef:
+      kind: OCIRepository
+      name: kyverno
+      namespace: flux-system
+    driftDetection:
+      mode: enabled
+    install:
+      remediation:
+        retries: 3
+    interval: 5m
+    upgrade:
+      cleanupOnFail: true
+      remediation:
+        retries: 3
+        strategy: rollback
   ---
   apiVersion: helm.toolkit.fluxcd.io/v2beta1
   kind: HelmRelease
@@ -4742,8 +4840,8 @@
     name: metallb
     namespace: metallb
     annotations:
-      config.kubernetes.io/index: '0'
-      internal.config.kubernetes.io/index: '0'
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
   spec:
     chart:
       spec:
@@ -4775,8 +4873,8 @@
     name: weave-gitops
     namespace: flux-system
     annotations:
-      config.kubernetes.io/index: '1'
-      internal.config.kubernetes.io/index: '1'
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
   spec:
     chart:
       spec:

--- a/tests/tool/__snapshots__/test_get_cluster.ambr
+++ b/tests/tool/__snapshots__/test_get_cluster.ambr
@@ -124,6 +124,12 @@
       path: tests/testdata/cluster/infrastructure/controllers
       helm_repos: []
       helm_releases:
+      - name: kyverno
+        namespace: kyverno
+        chart_ref:
+          kind: OCIRepository
+          name: kyverno
+          namespace: flux-system
       - name: metallb
         namespace: metallb
         chart:
@@ -208,6 +214,12 @@
       path: tests/testdata/cluster/infrastructure/controllers
       helm_repos: []
       helm_releases:
+      - name: kyverno
+        namespace: kyverno
+        chart_ref:
+          kind: OCIRepository
+          name: kyverno
+          namespace: flux-system
       - name: metallb
         namespace: metallb
         chart:

--- a/tests/tool/__snapshots__/test_get_ks.ambr
+++ b/tests/tool/__snapshots__/test_get_ks.ambr
@@ -99,7 +99,7 @@
   apps                 tests/testdata/cluster/apps/prod                     0            1           
   flux-system          tests/testdata/cluster/clusters/prod                 0            0           
   infra-configs        tests/testdata/cluster/infrastructure/configs        3            0           
-  infra-controllers    tests/testdata/cluster/infrastructure/controllers    0            2           
+  infra-controllers    tests/testdata/cluster/infrastructure/controllers    0            3           
   
   '''
 # ---


### PR DESCRIPTION
This patch adds minimal support for parsing HelmRelease objects with
a `chartRef` field instead of a `chart`. There is no support for
processing such releases in any way, but at least flux-local won't abort
during parsing.