### PR TITLE
Update flux build to have parity with other flux commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,39 +58,27 @@ use `kustomize build`, which is used underneath. Here is an example to build all
 the yaml output:
 
 ```bash
-$ flux-local build ks tests/testdata/cluster/ | kustomize cfg count
+$ flux-local build ks --path tests/testdata/cluster/ | kustomize cfg count
+Certificate: 2
 ClusterPolicy: 1
-ConfigMap: 1
-HelmRelease: 2
-HelmRepository: 2
+ConfigMap: 2
+GitRepository: 1
+HelmRelease: 3
+HelmRepository: 3
+Kustomization: 4
 Namespace: 1
 ```
 
-You can also specify the root to build all clusters.
-
-Additionally, you can inflate `HelmRelease` objects inside each `Kustomization` by adding
-the `--enable-helm` command line flag. This example again shows `kustomize cfg count`
-to parse the yaml output which now includes the resources from `HelmRelease` objects
-defined in the cluster:
+Additionally, you can inflate `HelmRelease` objects inside a `Kustomization`. This example
+again shows `kustomize cfg count` to parse the yaml output of an inflated `HelmRelease`
+objects defined in the cluster:
 
 ```bash
-$ flux-local build tests/testdata/cluster/ --enable-helm --skip-crds | kustomize cfg count
-ClusterPolicy: 1
-ClusterRole: 2
-ClusterRoleBinding: 2
-ConfigMap: 3
-DaemonSet: 1
-Deployment: 3
-HelmRelease: 2
-HelmRepository: 2
+$ flux-local build hr podinfo -n podinfo --path tests/testdata/cluster/ | kustomize cfg count
+ConfigMap: 1
+Deployment: 2
 Ingress: 1
-Namespace: 1
-Role: 3
-RoleBinding: 3
-Secret: 1
-Service: 3
-ServiceAccount: 2
-ValidatingWebhookConfiguration: 1
+Service: 2
 ```
 
 ### flux-local diff

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ metallb    4.1.14      metallb-metallb    bitnami
 
 ### flux-local build
 
-You can use the `flux-local` cli to build all objects in a cluster, similar to how you
+You can use the `flux-local` cli to build objects in a cluster, similar to how you
 use `kustomize build`, which is used underneath. Here is an example to build all flux
 `Kustomization` objects within a git repository, using `kustomize cfg count` to parse
 the yaml output:
 
 ```bash
-$ flux-local build tests/testdata/cluster/ | kustomize cfg count
+$ flux-local build ks tests/testdata/cluster/ | kustomize cfg count
 ClusterPolicy: 1
 ConfigMap: 1
 HelmRelease: 2

--- a/tests/testdata/cluster9/apps/podinfo/repository.yaml
+++ b/tests/testdata/cluster9/apps/podinfo/repository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   url: oci://ghcr.io/stefanprodan/charts/podinfo
   ref:
-    semver: ">= 6.0.0"
+    semver: "== 6.7.1"

--- a/tests/tool/__snapshots__/test_build.ambr
+++ b/tests/tool/__snapshots__/test_build.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_build[build-cluster2]
+# name: test_build_all[build-cluster2]
   '''
   ---
   apiVersion: v1
@@ -427,7 +427,7 @@
   
   '''
 # ---
-# name: test_build[build-cluster3]
+# name: test_build_all[build-cluster3]
   '''
   ---
   apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -531,7 +531,7 @@
   
   '''
 # ---
-# name: test_build[build-cluster6]
+# name: test_build_all[build-cluster6]
   '''
   ---
   apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -654,7 +654,7 @@
   
   '''
 # ---
-# name: test_build[build-helm-cluster6]
+# name: test_build_all[build-helm-cluster6]
   '''
   ---
   apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -852,7 +852,7 @@
   
   '''
 # ---
-# name: test_build[build-helm-cluster8-valuesFrom]
+# name: test_build_all[build-helm-cluster8-valuesFrom]
   '''
   ---
   apiVersion: v1
@@ -1630,7 +1630,7 @@
   
   '''
 # ---
-# name: test_build[build-helm-cluster9]
+# name: test_build_all[build-helm-cluster9]
   '''
   ---
   apiVersion: helm.toolkit.fluxcd.io/v2beta2
@@ -1685,7 +1685,7 @@
       mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
       operation: copy
     ref:
-      semver: '>= 6.0.0'
+      semver: == 6.7.1
     url: oci://ghcr.io/stefanprodan/charts/podinfo
   ---
   apiVersion: helm.toolkit.fluxcd.io/v2
@@ -2716,9 +2716,9 @@
   metadata:
     name: podinfo
     labels:
-      helm.sh/chart: podinfo-6.7.0
+      helm.sh/chart: podinfo-6.7.1
       app.kubernetes.io/name: podinfo
-      app.kubernetes.io/version: "6.7.0"
+      app.kubernetes.io/version: "6.7.1"
       app.kubernetes.io/managed-by: Helm
     annotations:
       config.kubernetes.io/index: '0'
@@ -2743,9 +2743,9 @@
   metadata:
     name: podinfo
     labels:
-      helm.sh/chart: podinfo-6.7.0
+      helm.sh/chart: podinfo-6.7.1
       app.kubernetes.io/name: podinfo
-      app.kubernetes.io/version: "6.7.0"
+      app.kubernetes.io/version: "6.7.1"
       app.kubernetes.io/managed-by: Helm
     annotations:
       config.kubernetes.io/index: '1'
@@ -2770,7 +2770,7 @@
         terminationGracePeriodSeconds: 30
         containers:
         - name: podinfo
-          image: "ghcr.io/stefanprodan/podinfo:6.7.0"
+          image: "ghcr.io/stefanprodan/podinfo:6.7.1"
           imagePullPolicy: IfNotPresent
           command:
           - ./podinfo
@@ -2834,7 +2834,7 @@
   
   '''
 # ---
-# name: test_build[build-helm-cluster]
+# name: test_build_all[build-helm-cluster]
   '''
   ---
   apiVersion: v1
@@ -4577,7 +4577,1705 @@
   
   '''
 # ---
-# name: test_build[build]
+# name: test_build_all[build]
+  '''
+  ---
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: podinfo
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    chart:
+      spec:
+        chart: podinfo
+        sourceRef:
+          kind: HelmRepository
+          name: podinfo
+          namespace: flux-system
+        version: 6.3.2
+    install:
+      remediation:
+        retries: 3
+    interval: 50m
+    releaseName: podinfo
+    values:
+      ingress:
+        additionalLabels:
+          cluster_label: example-value
+        className: nginx
+        enabled: true
+        hosts:
+        - host: podinfo.production
+          paths:
+          - path: /
+            pathType: ImplementationSpecific
+      redis:
+        enabled: true
+        repository: public.ecr.aws/docker/library/redis
+        tag: 7.0.6
+  ---
+  apiVersion: v1
+  data:
+    foo: bar
+  kind: ConfigMap
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo-config
+    namespace: podinfo
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  ---
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: example-com-staging
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    commonName: example.com
+    dnsNames:
+    - example.com
+    - '*.example.com'
+    issuerRef:
+      kind: ClusterIssuer
+      name: letsencrypt-staging
+    secretName: example-com-staging-tls
+  ---
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: other-com-staging
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    commonName: other.com
+    dnsNames:
+    - other.com
+    - '*.other.com'
+    - example-value
+    issuerRef:
+      kind: ClusterIssuer
+      name: letsencrypt-staging
+    secretName: other-com-staging-tls
+  
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1
+  kind: Kustomization
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: flux-system
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: apps
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    dependsOn:
+    - name: infra-configs
+    interval: 10m0s
+    path: ./tests/testdata/cluster/apps/prod
+    postBuild:
+      substitute:
+        cluster_env: production
+      substituteFrom:
+      - kind: ConfigMap
+        name: cluster-config
+    prune: true
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+    timeout: 5m0s
+    wait: true
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: GitRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: flux-system
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: flux-system
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    interval: 1m0s
+    ref:
+      branch: main
+    secretRef:
+      name: flux-system
+    url: ssh://git@github.com/allenporter/flux-local
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1
+  kind: Kustomization
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: flux-system
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: flux-system
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    interval: 10m0s
+    path: ./tests/testdata/cluster/clusters/prod
+    prune: true
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+  ---
+  apiVersion: v1
+  data:
+    SECRET_DOMAIN: example.com
+    SECRET_DOMAIN2: other.com
+    cluster_label: example-value
+  kind: ConfigMap
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: flux-system
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: cluster-config
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1
+  kind: Kustomization
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: flux-system
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: infra-controllers
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    interval: 1h
+    path: ./tests/testdata/cluster/infrastructure/controllers
+    prune: true
+    retryInterval: 1m
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+    timeout: 5m
+    wait: true
+  ---
+  apiVersion: kustomize.toolkit.fluxcd.io/v1
+  kind: Kustomization
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: flux-system
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: infra-configs
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '5'
+      internal.config.kubernetes.io/index: '5'
+  spec:
+    dependsOn:
+    - name: infra-controllers
+    interval: 1h
+    path: ./tests/testdata/cluster/infrastructure/configs
+    prune: true
+    retryInterval: 1m
+    sourceRef:
+      kind: GitRepository
+      name: flux-system
+    timeout: 5m
+  
+  ---
+  apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  metadata:
+    annotations:
+      policies.kyverno.io/description: Policy that is expected to allow resources under test through since no resources should have this annotation.
+      policies.kyverno.io/title: Test Allow Policy
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-configs
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: test-allow-policy
+  spec:
+    background: true
+    rules:
+    - match:
+        resources:
+          kinds:
+          - ConfigMap
+      name: forbid-test-annotation
+      validate:
+        message: Found test-annotation
+        pattern:
+          metadata:
+            =(annotations):
+              X(flux-local/test-annotation): "null"
+    validationFailureAction: audit
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-configs
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: bitnami
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    interval: 30m
+    provider: generic
+    timeout: 1m0s
+    url: https://charts.bitnami.com/bitnami
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-configs
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    interval: 5m
+    type: oci
+    url: oci://ghcr.io/stefanprodan/charts
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-configs
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: weave-charts
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    interval: 120m
+    type: oci
+    url: oci://ghcr.io/weaveworks/charts
+  
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-controllers
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: metallb
+    namespace: metallb
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    chart:
+      spec:
+        chart: metallb
+        reconcileStrategy: ChartVersion
+        sourceRef:
+          kind: HelmRepository
+          name: bitnami
+          namespace: flux-system
+        version: 4.1.14
+    install:
+      crds: CreateReplace
+      remediation:
+        retries: 3
+    interval: 5m
+    releaseName: metallb
+    upgrade:
+      crds: CreateReplace
+    values:
+      speaker:
+        secretName: metallb-secret
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: infra-controllers
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: weave-gitops
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    chart:
+      spec:
+        chart: weave-gitops
+        interval: 12h
+        sourceRef:
+          kind: HelmRepository
+          name: weave-charts
+        version: 4.0.22
+    interval: 60m
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr-single-cluster6]
+  '''
+  ---
+  # Source: renovate/templates/serviceaccount.yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: renovate
+    labels:
+      helm.sh/chart: renovate-37.64.3
+      app.kubernetes.io/name: renovate
+      app.kubernetes.io/instance: renovate
+      app.kubernetes.io/version: "37.64.3"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  ---
+  # Source: renovate/templates/cronjob.yaml
+  apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: renovate
+    labels:
+      helm.sh/chart: renovate-37.64.3
+      app.kubernetes.io/name: renovate
+      app.kubernetes.io/instance: renovate
+      app.kubernetes.io/version: "37.64.3"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    schedule: "0 1 * * *"
+    jobTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/name: renovate
+          app.kubernetes.io/instance: renovate
+      spec:
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: renovate
+              app.kubernetes.io/instance: renovate
+          spec:
+            serviceAccountName: renovate
+            restartPolicy: Never
+            containers:
+            - name: renovate
+              image: "ghcr.io/renovatebot/renovate:37.64.3"
+              imagePullPolicy: IfNotPresent
+              env:
+              - name: RENOVATE_CONFIG_FILE
+                value: /dev/null
+              envFrom:
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+              resources:
+                limits:
+                  cpu: 1000m
+                  memory: 2G
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+            volumes:
+            securityContext:
+              fsGroup: 1000
+              fsGroupChangePolicy: Always
+              runAsNonRoot: true
+              runAsUser: 1000
+              seccompProfile:
+                type: RuntimeDefault
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr-single-cluster8]
+  '''
+  ---
+  # Source: podinfo/templates/redis/config.yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: podinfo-redis
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  data:
+    redis.conf: |
+      maxmemory 64mb
+      maxmemory-policy allkeys-lru
+      save ""
+      appendonly no
+  ---
+  # Source: podinfo/templates/redis/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: podinfo-redis
+    labels:
+      app: podinfo-redis
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    type: ClusterIP
+    selector:
+      app: podinfo-redis
+    ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  ---
+  # Source: podinfo/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.5.4
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.5.4"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    type: ClusterIP
+    ports:
+    - port: 9898
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 9999
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    selector:
+      app.kubernetes.io/name: podinfo
+  ---
+  # Source: podinfo/templates/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.5.4
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.5.4"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    replicas: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: podinfo
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: podinfo
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9898"
+      spec:
+        terminationGracePeriodSeconds: 30
+        containers:
+        - name: podinfo
+          image: "ghcr.io/stefanprodan/podinfo:6.5.4"
+          imagePullPolicy: IfNotPresent
+          command:
+          - ./podinfo
+          - --port=9898
+          - --cert-path=/data/cert
+          - --port-metrics=9797
+          - --grpc-port=9999
+          - --grpc-service-name=podinfo
+          - --cache-server=tcp://podinfo-redis:6379
+          - --level=info
+          - --random-delay=false
+          - --random-error=false
+          env:
+          - name: PODINFO_UI_COLOR
+            value: "#34577c"
+          ports:
+          - name: http
+            containerPort: 9898
+            protocol: TCP
+          - name: http-metrics
+            containerPort: 9797
+            protocol: TCP
+          - name: grpc
+            containerPort: 9999
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:9898/healthz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:9898/readyz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            periodSeconds: 10
+          volumeMounts:
+          - name: data
+            mountPath: /data
+          resources:
+            limits: null
+            requests:
+              cpu: 1m
+              memory: 16Mi
+        volumes:
+        - name: data
+          emptyDir: {}
+  ---
+  # Source: podinfo/templates/redis/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: podinfo-redis
+    labels:
+      app: podinfo-redis
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        app: podinfo-redis
+    template:
+      metadata:
+        labels:
+          app: podinfo-redis
+        annotations:
+          checksum/config: "34c601c9d39797bbf53d1c7a278976609301f637ec11dc0253563729dfad4f8e"
+      spec:
+        containers:
+        - name: redis
+          image: "public.ecr.aws/docker/library/redis:7.0.6"
+          imagePullPolicy: IfNotPresent
+          command:
+          - redis-server
+          - "/redis-master/redis.conf"
+          ports:
+          - name: redis
+            containerPort: 6379
+            protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - redis-cli
+              - ping
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+          - mountPath: /var/lib/redis
+            name: data
+          - mountPath: /redis-master
+            name: config
+        volumes:
+        - name: data
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: podinfo-redis
+            items:
+            - key: redis.conf
+              path: redis.conf
+  ---
+  # Source: podinfo/templates/ingress.yaml
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.5.4
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.5.4"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '5'
+      internal.config.kubernetes.io/index: '5'
+  spec:
+    ingressClassName: nginx
+    rules:
+    - host: "podinfo.production"
+      http:
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: podinfo
+              port:
+                number: 9898
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr-single-cluster9]
+  '''
+  ---
+  # Source: podinfo/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.7.1
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.7.1"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    type: ClusterIP
+    ports:
+    - port: 9898
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 9999
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    selector:
+      app.kubernetes.io/name: podinfo
+  ---
+  # Source: podinfo/templates/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.7.1
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.7.1"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    replicas: 2
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: podinfo
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: podinfo
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9898"
+      spec:
+        terminationGracePeriodSeconds: 30
+        containers:
+        - name: podinfo
+          image: "ghcr.io/stefanprodan/podinfo:6.7.1"
+          imagePullPolicy: IfNotPresent
+          command:
+          - ./podinfo
+          - --port=9898
+          - --cert-path=/data/cert
+          - --port-metrics=9797
+          - --grpc-port=9999
+          - --grpc-service-name=podinfo
+          - --level=info
+          - --random-delay=false
+          - --random-error=false
+          env:
+          - name: PODINFO_UI_COLOR
+            value: "#34577c"
+          ports:
+          - name: http
+            containerPort: 9898
+            protocol: TCP
+          - name: http-metrics
+            containerPort: 9797
+            protocol: TCP
+          - name: grpc
+            containerPort: 9999
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:9898/healthz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:9898/readyz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            periodSeconds: 10
+          volumeMounts:
+          - name: data
+            mountPath: /data
+          resources:
+            limits: null
+            requests:
+              cpu: 1m
+              memory: 16Mi
+        volumes:
+        - name: data
+          emptyDir: {}
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr-single]
+  '''
+  ---
+  # Source: weave-gitops/templates/network-policy.yaml
+  apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-dashboard-ingress
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: weave-gitops
+        app.kubernetes.io/instance: weave-gitops
+    ingress:
+    - ports:
+      - port: 9001
+        protocol: TCP
+    policyTypes:
+    - Ingress
+  ---
+  # Source: weave-gitops/templates/network-policy.yaml
+  apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-dashboard-egress
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: weave-gitops
+        app.kubernetes.io/instance: weave-gitops
+    egress:
+    - {}
+    policyTypes:
+    - Egress
+  ---
+  # Source: weave-gitops/templates/serviceaccount.yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  ---
+  # Source: weave-gitops/templates/role.yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: weave-gitops
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  rules:
+  # impersonation rules for ui calls
+  - apiGroups: [""]
+    resources: ["users", "groups"]
+    verbs: ["impersonate"]
+  # Access to enterprise entitlement
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+    # or should return the first non-falsy result
+    resourceNames: ["cluster-user-auth", "oidc-auth"]
+  # The service account needs to read namespaces to know where it can query
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  # The service account needs to list custom resources to query if given feature
+  # is available or not.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list"]
+  ---
+  # Source: weave-gitops/templates/rolebinding.yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  subjects:
+  - kind: ServiceAccount
+    name: weave-gitops
+    namespace: flux-system
+  roleRef:
+    kind: ClusterRole
+    name: weave-gitops
+    apiGroup: rbac.authorization.k8s.io
+  ---
+  # Source: weave-gitops/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '5'
+      internal.config.kubernetes.io/index: '5'
+  spec:
+    type: ClusterIP
+    ports:
+    - port: 9001
+      targetPort: http
+      protocol: TCP
+      name: http
+    selector:
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+  ---
+  # Source: weave-gitops/templates/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: weave-gitops
+      weave.works/app: weave-gitops-oss
+    annotations:
+      config.kubernetes.io/index: '6'
+      internal.config.kubernetes.io/index: '6'
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: weave-gitops
+        app.kubernetes.io/instance: weave-gitops
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: weave-gitops
+          app.kubernetes.io/instance: weave-gitops
+          app.kubernetes.io/part-of: weave-gitops
+          weave.works/app: weave-gitops-oss
+      spec:
+        serviceAccountName: weave-gitops
+        securityContext: {}
+        containers:
+        - name: weave-gitops
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/weaveworks/wego-app:v0.24.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - "--log-level"
+          - "info"
+          - "--insecure"
+          ports:
+          - name: http
+            containerPort: 9001
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          env:
+          - name: WEAVE_GITOPS_FEATURE_TENANCY
+            value: "true"
+          - name: WEAVE_GITOPS_FEATURE_CLUSTER
+            value: "false"
+          resources: {}
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr]
+  '''
+  ---
+  # Source: weave-gitops/templates/network-policy.yaml
+  apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-dashboard-ingress
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: weave-gitops
+        app.kubernetes.io/instance: weave-gitops
+    ingress:
+    - ports:
+      - port: 9001
+        protocol: TCP
+    policyTypes:
+    - Ingress
+  ---
+  # Source: weave-gitops/templates/network-policy.yaml
+  apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-dashboard-egress
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: weave-gitops
+        app.kubernetes.io/instance: weave-gitops
+    egress:
+    - {}
+    policyTypes:
+    - Egress
+  ---
+  # Source: weave-gitops/templates/serviceaccount.yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  ---
+  # Source: weave-gitops/templates/role.yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: weave-gitops
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  rules:
+  # impersonation rules for ui calls
+  - apiGroups: [""]
+    resources: ["users", "groups"]
+    verbs: ["impersonate"]
+  # Access to enterprise entitlement
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+    # or should return the first non-falsy result
+    resourceNames: ["cluster-user-auth", "oidc-auth"]
+  # The service account needs to read namespaces to know where it can query
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  # The service account needs to list custom resources to query if given feature
+  # is available or not.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list"]
+  ---
+  # Source: weave-gitops/templates/rolebinding.yaml
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  subjects:
+  - kind: ServiceAccount
+    name: weave-gitops
+    namespace: flux-system
+  roleRef:
+    kind: ClusterRole
+    name: weave-gitops
+    apiGroup: rbac.authorization.k8s.io
+  ---
+  # Source: weave-gitops/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '5'
+      internal.config.kubernetes.io/index: '5'
+  spec:
+    type: ClusterIP
+    ports:
+    - port: 9001
+      targetPort: http
+      protocol: TCP
+      name: http
+    selector:
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+  ---
+  # Source: weave-gitops/templates/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: weave-gitops
+    labels:
+      helm.sh/chart: weave-gitops-4.0.22
+      app.kubernetes.io/name: weave-gitops
+      app.kubernetes.io/instance: weave-gitops
+      app.kubernetes.io/version: "v0.24.0"
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: weave-gitops
+      weave.works/app: weave-gitops-oss
+    annotations:
+      config.kubernetes.io/index: '6'
+      internal.config.kubernetes.io/index: '6'
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: weave-gitops
+        app.kubernetes.io/instance: weave-gitops
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: weave-gitops
+          app.kubernetes.io/instance: weave-gitops
+          app.kubernetes.io/part-of: weave-gitops
+          weave.works/app: weave-gitops-oss
+      spec:
+        serviceAccountName: weave-gitops
+        securityContext: {}
+        containers:
+        - name: weave-gitops
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/weaveworks/wego-app:v0.24.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - "--log-level"
+          - "info"
+          - "--insecure"
+          ports:
+          - name: http
+            containerPort: 9001
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          env:
+          - name: WEAVE_GITOPS_FEATURE_TENANCY
+            value: "true"
+          - name: WEAVE_GITOPS_FEATURE_CLUSTER
+            value: "false"
+          resources: {}
+  
+  
+  '''
+# ---
+# name: test_build_ks[build-ks-single-cluster6]
+  '''
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: renovate
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    interval: 30m
+    url: https://docs.renovatebot.com/helm-charts
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: renovate
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    chart:
+      spec:
+        chart: renovate
+        sourceRef:
+          kind: HelmRepository
+          name: renovate
+          namespace: flux-system
+        version: 37.64.3
+    interval: 5m
+    values:
+      renovate:
+        existingConfigFile: /dev/null
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 2G
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccount:
+        create: true
+  
+  
+  '''
+# ---
+# name: test_build_ks[build-ks-single-cluster8]
+  '''
+  ---
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: mnt-pod
+    namespace: home
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    containers:
+    - args:
+      - -c
+      - sleep 500000
+      command:
+      - /bin/sh
+      image: alpine
+      name: task-pv-container
+      volumeMounts:
+      - mountPath: /data
+        name: task-pv-storage
+    volumes:
+    - name: task-pv-storage
+      persistentVolumeClaim:
+        claimName: some-pod-datadir
+  ---
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: sleep
+    namespace: home
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    initContainers:
+    - args:
+      - -c
+      - sleep 500000
+      command:
+      - /bin/sh
+      image: busybox
+      name: sleep
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: HelmRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    interval: 5m
+    type: oci
+    url: oci://ghcr.io/stefanprodan/charts
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: podinfo
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    chart:
+      spec:
+        chart: podinfo
+        sourceRef:
+          kind: HelmRepository
+          name: podinfo
+          namespace: flux-system
+        version: 6.5.4
+    install:
+      remediation:
+        retries: 3
+    interval: 50m
+    releaseName: podinfo
+    valuesFrom:
+    - kind: ConfigMap
+      name: podinfo-values
+    - kind: Secret
+      name: podinfo-tls-values
+      optional: true
+      targetPath: tls.crt
+      valuesKey: crt
+  ---
+  apiVersion: v1
+  data:
+    values.yaml: |-
+      redis:
+        enabled: true
+        repository: public.ecr.aws/docker/library/redis
+        tag: 7.0.6
+      ingress:
+        enabled: true
+        className: nginx
+        hosts:
+          - host: podinfo.production
+            paths:
+              - path: /
+                pathType: ImplementationSpecific
+  kind: ConfigMap
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo-values
+    namespace: podinfo
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1
+  kind: HelmRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: tailscale
+    namespace: flux-system
+    annotations:
+      config.kubernetes.io/index: '6'
+      internal.config.kubernetes.io/index: '6'
+  spec:
+    interval: 30m
+    timeout: 3m
+    url: https://pkgs.tailscale.com/helmcharts
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta2
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: tailscale-operator
+    namespace: network
+    annotations:
+      config.kubernetes.io/index: '7'
+      internal.config.kubernetes.io/index: '7'
+  spec:
+    chart:
+      spec:
+        chart: tailscale-operator
+        interval: 30m
+        sourceRef:
+          kind: HelmRepository
+          name: tailscale
+          namespace: flux-system
+        version: 1.68.1
+    interval: 30m
+    values:
+      apiServerProxyConfig:
+        mode: "true"
+      operatorConfig:
+        defaultTags:
+        - tag:k8s
+        hostname: tailscale-operator
+    valuesFrom:
+    - kind: Secret
+      name: tailscale-operator
+      targetPath: oauth.clientId
+      valuesKey: client_id
+    - kind: Secret
+      name: tailscale-operator
+      targetPath: oauth.clientSecret
+      valuesKey: client_secret
+  
+  
+  '''
+# ---
+# name: test_build_ks[build-ks-single-cluster9]
+  '''
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta2
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps-stack
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: nginx
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    chart:
+      spec:
+        chart: ./tests/testdata/cluster9/local-charts/nginx
+        interval: 2h
+        sourceRef:
+          kind: GitRepository
+          name: flux-system
+          namespace: flux-system
+    driftDetection:
+      mode: enabled
+    install:
+      remediation:
+        retries: 3
+    interval: 3h
+    maxHistory: 5
+    releaseName: nginx
+    timeout: 10m
+    uninstall:
+      keepHistory: false
+    upgrade:
+      remediation:
+        retries: 3
+  ---
+  apiVersion: source.toolkit.fluxcd.io/v1beta2
+  kind: OCIRepository
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps-stack
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    interval: 10m
+    layerSelector:
+      mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+      operation: copy
+    ref:
+      semver: == 6.7.1
+    url: oci://ghcr.io/stefanprodan/charts/podinfo
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps-stack
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    chartRef:
+      kind: OCIRepository
+      name: podinfo
+      namespace: default
+    interval: 10m
+    values:
+      replicaCount: 2
+  
+  
+  '''
+# ---
+# name: test_build_ks[build-ks-single]
+  '''
+  ---
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  ---
+  apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  kind: HelmRelease
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo
+    namespace: podinfo
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    chart:
+      spec:
+        chart: podinfo
+        sourceRef:
+          kind: HelmRepository
+          name: podinfo
+          namespace: flux-system
+        version: 6.3.2
+    install:
+      remediation:
+        retries: 3
+    interval: 50m
+    releaseName: podinfo
+    values:
+      ingress:
+        additionalLabels:
+          cluster_label: example-value
+        className: nginx
+        enabled: true
+        hosts:
+        - host: podinfo.production
+          paths:
+          - path: /
+            pathType: ImplementationSpecific
+      redis:
+        enabled: true
+        repository: public.ecr.aws/docker/library/redis
+        tag: 7.0.6
+  ---
+  apiVersion: v1
+  data:
+    foo: bar
+  kind: ConfigMap
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: podinfo-config
+    namespace: podinfo
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  ---
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: example-com-staging
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    commonName: example.com
+    dnsNames:
+    - example.com
+    - '*.example.com'
+    issuerRef:
+      kind: ClusterIssuer
+      name: letsencrypt-staging
+    secretName: example-com-staging-tls
+  ---
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    labels:
+      kustomize.toolkit.fluxcd.io/name: apps
+      kustomize.toolkit.fluxcd.io/namespace: flux-system
+    name: other-com-staging
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    commonName: other.com
+    dnsNames:
+    - other.com
+    - '*.other.com'
+    - example-value
+    issuerRef:
+      kind: ClusterIssuer
+      name: letsencrypt-staging
+    secretName: other-com-staging-tls
+  
+  
+  '''
+# ---
+# name: test_build_ks[build-ks]
   '''
   ---
   apiVersion: v1

--- a/tests/tool/__snapshots__/test_build.ambr
+++ b/tests/tool/__snapshots__/test_build.ambr
@@ -4953,6 +4953,264 @@
   
   '''
 # ---
+# name: test_build_hr[build-hr-cluster3]
+  '''
+  ---
+  # Source: podinfo/templates/redis/config.yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: podinfo-redis
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  data:
+    redis.conf: |
+      maxmemory 64mb
+      maxmemory-policy allkeys-lru
+      save ""
+      appendonly no
+  ---
+  # Source: podinfo/templates/redis/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: podinfo-redis
+    labels:
+      app: podinfo-redis
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    type: ClusterIP
+    selector:
+      app: podinfo-redis
+    ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  ---
+  # Source: podinfo/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.7.1
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.7.1"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    type: ClusterIP
+    ports:
+    - port: 9898
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 9999
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    selector:
+      app.kubernetes.io/name: podinfo
+  ---
+  # Source: podinfo/templates/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.7.1
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.7.1"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    replicas: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: podinfo
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: podinfo
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "9898"
+      spec:
+        terminationGracePeriodSeconds: 30
+        containers:
+        - name: podinfo
+          image: "ghcr.io/stefanprodan/podinfo:6.7.1"
+          imagePullPolicy: IfNotPresent
+          command:
+          - ./podinfo
+          - --port=9898
+          - --cert-path=/data/cert
+          - --port-metrics=9797
+          - --grpc-port=9999
+          - --grpc-service-name=podinfo
+          - --cache-server=tcp://podinfo-redis:6379
+          - --level=info
+          - --random-delay=false
+          - --random-error=false
+          env:
+          - name: PODINFO_UI_COLOR
+            value: "#34577c"
+          ports:
+          - name: http
+            containerPort: 9898
+            protocol: TCP
+          - name: http-metrics
+            containerPort: 9797
+            protocol: TCP
+          - name: grpc
+            containerPort: 9999
+            protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:9898/healthz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:9898/readyz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+            periodSeconds: 10
+          volumeMounts:
+          - name: data
+            mountPath: /data
+          resources:
+            limits: null
+            requests:
+              cpu: 1m
+              memory: 16Mi
+        volumes:
+        - name: data
+          emptyDir: {}
+  ---
+  # Source: podinfo/templates/redis/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: podinfo-redis
+    labels:
+      app: podinfo-redis
+    annotations:
+      config.kubernetes.io/index: '4'
+      internal.config.kubernetes.io/index: '4'
+  spec:
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        app: podinfo-redis
+    template:
+      metadata:
+        labels:
+          app: podinfo-redis
+        annotations:
+          checksum/config: "34c601c9d39797bbf53d1c7a278976609301f637ec11dc0253563729dfad4f8e"
+      spec:
+        containers:
+        - name: redis
+          image: "public.ecr.aws/docker/library/redis:7.0.6"
+          imagePullPolicy: IfNotPresent
+          command:
+          - redis-server
+          - "/redis-master/redis.conf"
+          ports:
+          - name: redis
+            containerPort: 6379
+            protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - redis-cli
+              - ping
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+          - mountPath: /var/lib/redis
+            name: data
+          - mountPath: /redis-master
+            name: config
+        volumes:
+        - name: data
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: podinfo-redis
+            items:
+            - key: redis.conf
+              path: redis.conf
+  ---
+  # Source: podinfo/templates/ingress.yaml
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: podinfo
+    labels:
+      helm.sh/chart: podinfo-6.7.1
+      app.kubernetes.io/name: podinfo
+      app.kubernetes.io/version: "6.7.1"
+      app.kubernetes.io/managed-by: Helm
+    annotations:
+      config.kubernetes.io/index: '5'
+      internal.config.kubernetes.io/index: '5'
+  spec:
+    ingressClassName: nginx
+    rules:
+    - host: "podinfo.local"
+      http:
+        paths:
+        - path: /
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: podinfo
+              port:
+                number: 9898
+  
+  
+  '''
+# ---
 # name: test_build_hr[build-hr-single-cluster6]
   '''
   ---

--- a/tests/tool/test_build.py
+++ b/tests/tool/test_build.py
@@ -25,7 +25,13 @@ from . import run_command
             ]
         ),
         (["--enable-helm", "--no-skip-secrets", "tests/testdata/cluster8/"]),
-        (["--enable-helm", "--no-skip-secrets", "tests/testdata/cluster9/clusters/dev"]),
+        (
+            [
+                "--enable-helm",
+                "--no-skip-secrets",
+                "tests/testdata/cluster9/clusters/dev",
+            ]
+        ),
     ],
     ids=[
         "build",
@@ -38,7 +44,73 @@ from . import run_command
         "build-helm-cluster9",
     ],
 )
-async def test_build(args: list[str], snapshot: SnapshotAssertion) -> None:
+async def test_build_all(args: list[str], snapshot: SnapshotAssertion) -> None:
     """Test build commands."""
-    result = await run_command(["build"] + args)
+    result = await run_command(["build", "all"] + args)
+    assert result == snapshot
+
+
+@pytest.mark.parametrize(
+    ("args"),
+    [
+        (["--path=tests/testdata/cluster/"]),
+        (["apps", "--path=tests/testdata/cluster/"]),
+        (["apps", "--path=tests/testdata/cluster6/"]),
+        (["apps", "--path=tests/testdata/cluster8/"]),
+        (["apps-stack", "--path=tests/testdata/cluster9/clusters/dev"]),
+    ],
+    ids=[
+        "build-ks",
+        "build-ks-single",
+        "build-ks-single-cluster6",
+        "build-ks-single-cluster8",
+        "build-ks-single-cluster9",
+    ],
+)
+async def test_build_ks(args: list[str], snapshot: SnapshotAssertion) -> None:
+    """Test build commands."""
+    result = await run_command(["build", "ks"] + args)
+    assert result == snapshot
+
+
+@pytest.mark.parametrize(
+    ("args"),
+    [
+        (["--path=tests/testdata/cluster/"]),
+        (["weave-gitops", "--path=tests/testdata/cluster/"]),
+        (
+            [
+                "-A",
+                "--path",
+                "tests/testdata/cluster3",
+                "--sources",
+                "cluster=tests/testdata/cluster3",
+            ]
+        ),
+        (
+            [
+                "renovate",
+                "-A",
+                "--skip-crds",
+                "--path",
+                "tests/testdata/cluster6/",
+                "-a",
+                "batch/v1/CronJob",
+            ]
+        ),
+        (["podinfo", "-n", "podinfo", "--path=tests/testdata/cluster8/"]),
+        (["podinfo", "-n", "default", "--path=tests/testdata/cluster9/clusters/dev"]),
+    ],
+    ids=[
+        "build-hr",
+        "build-hr-single",
+        "build-hr-cluster3",
+        "build-hr-single-cluster6",
+        "build-hr-single-cluster8",
+        "build-hr-single-cluster9",
+    ],
+)
+async def test_build_hr(args: list[str], snapshot: SnapshotAssertion) -> None:
+    """Test build commands."""
+    result = await run_command(["build", "hr"] + args)
     assert result == snapshot


### PR DESCRIPTION
This is a breaking change that updates the format of the `flux build` command to have parity with `get` and `diff` commands.

Example to build a single kustomziation:
```bash
$ flux-local build ks apps --path tests/testdata/cluster/
```
Example to inflate a single helm release:
```bash
$ flux-local build hr podinfo -n podinfo --path tests/testdata/cluster
```

The old behavior `flux-local build tests/testdata/cluster/` can still be achieved with `build all`:
```bash
$ flux-local build all tests/testdata/cluster/
```

Fixes #795