### PR TITLE
Add deep-merge of values, and allow empty values file

### DIFF
--- a/flux_local/values.py
+++ b/flux_local/values.py
@@ -179,7 +179,11 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     result = base.copy()
     for key, override_value in override.items():
         base_value = result.get(key)
-        if base_value is not None and isinstance(base_value, dict) and isinstance(override_value, dict):
+        if (
+            base_value is not None
+            and isinstance(base_value, dict)
+            and isinstance(override_value, dict)
+        ):
             result[key] = _deep_merge(base_value, override_value)
         else:
             result[key] = override_value
@@ -301,4 +305,3 @@ def expand_postbuild_substitute_reference(
     _LOGGER.debug("update_postbuild_substitutions=%s", values)
     ks.update_postbuild_substitutions(values)
     return ks
-

--- a/flux_local/values.py
+++ b/flux_local/values.py
@@ -174,8 +174,8 @@ def _lookup_value_reference(
     return found_value
 
 def deep_merge(base: dict, override: dict) -> dict:
-    """
-    Recursively merge two dictionaries, similar to how Helm merges values.
+    """Recursively merge two dictionaries, similar to how Helm merges values.
+
     Lists are replaced entirely (Helm behavior).
     """
     result = base.copy()

--- a/tests/testdata/cluster8/apps/podinfo-values.yaml
+++ b/tests/testdata/cluster8/apps/podinfo-values.yaml
@@ -22,4 +22,3 @@ data:
   patch-values.yaml: |-
     redis:
       tag: 7.0.6
-

--- a/tests/testdata/cluster8/apps/podinfo-values.yaml
+++ b/tests/testdata/cluster8/apps/podinfo-values.yaml
@@ -9,7 +9,7 @@ data:
     redis:
       enabled: true
       repository: public.ecr.aws/docker/library/redis
-      tag: 7.0.6
+      tag: 7.0.5
     ingress:
       enabled: true
       className: nginx
@@ -18,3 +18,8 @@ data:
           paths:
             - path: /
               pathType: ImplementationSpecific
+  empty-values.yaml: ""
+  patch-values.yaml: |-
+    redis:
+      tag: 7.0.6
+

--- a/tests/testdata/cluster8/apps/podinfo.yaml
+++ b/tests/testdata/cluster8/apps/podinfo.yaml
@@ -42,4 +42,3 @@ spec:
       valuesKey: crt
       targetPath: tls.crt
       optional: true
-

--- a/tests/testdata/cluster8/apps/podinfo.yaml
+++ b/tests/testdata/cluster8/apps/podinfo.yaml
@@ -31,8 +31,15 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: podinfo-values
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: empty-values.yaml
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: patch-values.yaml
     - kind: Secret
       name: podinfo-tls-values
       valuesKey: crt
       targetPath: tls.crt
       optional: true
+

--- a/tests/tool/__snapshots__/test_build.ambr
+++ b/tests/tool/__snapshots__/test_build.ambr
@@ -948,6 +948,12 @@
     valuesFrom:
     - kind: ConfigMap
       name: podinfo-values
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: empty-values.yaml
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: patch-values.yaml
     - kind: Secret
       name: podinfo-tls-values
       optional: true
@@ -956,11 +962,15 @@
   ---
   apiVersion: v1
   data:
+    empty-values.yaml: ""
+    patch-values.yaml: |-
+      redis:
+        tag: 7.0.6
     values.yaml: |-
       redis:
         enabled: true
         repository: public.ecr.aws/docker/library/redis
-        tag: 7.0.6
+        tag: 7.0.5
       ingress:
         enabled: true
         className: nginx
@@ -6333,6 +6343,12 @@
     valuesFrom:
     - kind: ConfigMap
       name: podinfo-values
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: empty-values.yaml
+    - kind: ConfigMap
+      name: podinfo-values
+      valuesKey: patch-values.yaml
     - kind: Secret
       name: podinfo-tls-values
       optional: true
@@ -6341,11 +6357,15 @@
   ---
   apiVersion: v1
   data:
+    empty-values.yaml: ""
+    patch-values.yaml: |-
+      redis:
+        tag: 7.0.6
     values.yaml: |-
       redis:
         enabled: true
         repository: public.ecr.aws/docker/library/redis
-        tag: 7.0.6
+        tag: 7.0.5
       ingress:
         enabled: true
         className: nginx


### PR DESCRIPTION
Allow empty YAML values files.
Perform a deep merge instead of shallow, for better helm values patching.

(I was unable to locally run the tests, would like to check via the pipeline)