### PR TITLE
Fix merging of values to override inline values last

### DIFF
--- a/flux_local/values.py
+++ b/flux_local/values.py
@@ -230,7 +230,7 @@ def expand_value_references(
     if not helm_release.values_from:
         return helm_release
 
-    values = {}
+    values: dict[str, Any] = {}
     cluster_config = ks_cluster_config([kustomization])
     for ref in helm_release.values_from:
         _LOGGER.debug("Expanding value reference %s", ref)

--- a/flux_local/values.py
+++ b/flux_local/values.py
@@ -168,7 +168,7 @@ def _lookup_value_reference(
 
     elif (found_value := found_data.get(ref.values_key)) is None:
         raise InvalidValuesReference(
-            "Unable to find key {ref.values_key} in {namespace}/{ref.name}"
+            f"Unable to find key {ref.values_key} in {namespace}/{ref.name}"
         )
 
     return found_value
@@ -230,7 +230,7 @@ def expand_value_references(
     if not helm_release.values_from:
         return helm_release
 
-    values = helm_release.values or {}
+    values = {}
     cluster_config = ks_cluster_config([kustomization])
     for ref in helm_release.values_from:
         _LOGGER.debug("Expanding value reference %s", ref)
@@ -256,6 +256,9 @@ def expand_value_references(
             raise HelmException(
                 f"Error building HelmRelease '{helm_release.namespaced_name}': {err}"
             )
+
+    if helm_release.values:
+        values = _deep_merge(values, helm_release.values)
 
     helm_release.values = values
     return helm_release

--- a/tests/testdata/cluster8/apps/podinfo-values.yaml
+++ b/tests/testdata/cluster8/apps/podinfo-values.yaml
@@ -7,7 +7,6 @@ metadata:
 data:
   values.yaml: |-
     redis:
-      enabled: true
       repository: public.ecr.aws/docker/library/redis
       tag: 7.0.5
     ingress:

--- a/tests/testdata/cluster8/apps/podinfo.yaml
+++ b/tests/testdata/cluster8/apps/podinfo.yaml
@@ -28,6 +28,9 @@ spec:
   install:
     remediation:
       retries: 3
+  values:
+    redis:
+      enabled: true
   valuesFrom:
     - kind: ConfigMap
       name: podinfo-values

--- a/tests/tool/__snapshots__/test_build.ambr
+++ b/tests/tool/__snapshots__/test_build.ambr
@@ -945,6 +945,9 @@
         retries: 3
     interval: 50m
     releaseName: podinfo
+    values:
+      redis:
+        enabled: true
     valuesFrom:
     - kind: ConfigMap
       name: podinfo-values
@@ -968,7 +971,6 @@
         tag: 7.0.6
     values.yaml: |-
       redis:
-        enabled: true
         repository: public.ecr.aws/docker/library/redis
         tag: 7.0.5
       ingress:
@@ -6340,6 +6342,9 @@
         retries: 3
     interval: 50m
     releaseName: podinfo
+    values:
+      redis:
+        enabled: true
     valuesFrom:
     - kind: ConfigMap
       name: podinfo-values
@@ -6363,7 +6368,6 @@
         tag: 7.0.6
     values.yaml: |-
       redis:
-        enabled: true
         repository: public.ecr.aws/docker/library/redis
         tag: 7.0.5
       ingress:


### PR DESCRIPTION
https://fluxcd.io/flux/components/helm/helmreleases/#values-references specifies that `values` are merged last after any `valuesFrom` references.

Fixes #813 
