### PR TITLE
feat(actions): bump actions/setup-python to v5

### DIFF
--- a/action/test/action.yml
+++ b/action/test/action.yml
@@ -40,7 +40,7 @@ runs:
         cp ${{ github.action_path }}/../../requirements.txt $tempdir
         echo "directory=${tempdir}" >> $GITHUB_OUTPUT
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip


### PR DESCRIPTION
### Notes
I noticed when implementing `action/test` the caching step took a significant amount of time compared to the actual business logic. `action/diff` doesn't seem to have this behavior.

`action/diff` is using `actions/setup-python@v5`, while `action/test` is using `actions/setup-python@v4`. 

This is important as that action has updated `actions/cache@v4` which uses the newer V2 cache. Additionally, all prior versions of `actions/cache` will start failing in workflows on 2025-02-01.

Solution is to update `actions/setup-python` to the latest version.

### References

- https://github.com/actions/setup-python/pull/1007
- https://github.com/actions/toolkit/discussions/1890
