### PR TITLE
Add a flag --skip-kinds to omit kind from the output

### DIFF
--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -600,6 +600,8 @@ async def build_kustomization(
             skips.append(CRD_KIND)
         if kustomization_selector.skip_secrets:
             skips.append(SECRET_KIND)
+        if kustomization_selector.skip_kinds:
+            skips.extend(kustomization_selector.skip_kinds)
         cmd = cmd.skip_resources(skips)
         try:
             cmd = await cmd.stash()

--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -261,6 +261,9 @@ class MetadataSelector:
     skip_secrets: bool = True
     """If false, Secrets may be processed, depending on the resource type."""
 
+    skip_kinds: list[str] | None = None
+    """A list of potential CRDs to skip when emitting objects."""
+
     visitor: ResourceVisitor | None = None
     """Visitor for the specified object type that can be used for building."""
 

--- a/flux_local/helm.py
+++ b/flux_local/helm.py
@@ -137,6 +137,9 @@ class Options:
     skip_secrets: bool = False
     """Don't emit secrets in the output."""
 
+    skip_kinds: list[str] | None = None
+    """Omit these kinds in the output."""
+
     kube_version: str | None = None
     """Value of the helm --kube-version flag."""
 

--- a/flux_local/helm.py
+++ b/flux_local/helm.py
@@ -173,6 +173,8 @@ class Options:
             skips.append(CRD_KIND)
         if self.skip_secrets:
             skips.append(SECRET_KIND)
+        if self.skip_kinds:
+            skips.extend(self.skip_kinds)
         return skips
 
 

--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -65,6 +65,7 @@ class BuildAllAction:
         enable_helm: bool,
         skip_crds: bool,
         skip_secrets: bool,
+        skip_kinds: list[str],
         output_file: str,
         **kwargs,  # pylint: disable=unused-argument
     ) -> None:
@@ -74,10 +75,11 @@ class BuildAllAction:
         query.kustomization.namespace = None
         query.kustomization.skip_crds = skip_crds
         query.kustomization.skip_secrets = skip_secrets
+        query.kustomization.skip_kinds = skip_kinds
         query.helm_release.enabled = enable_helm
         query.helm_release.namespace = None
         helm_options = selector.build_helm_options(
-            skip_crds=skip_crds, skip_secrets=skip_secrets, **kwargs
+            skip_crds=skip_crds, skip_secrets=skip_secrets, skip_kinds=skip_kinds, **kwargs
         )
 
         content = ContentOutput()

--- a/flux_local/tool/selector.py
+++ b/flux_local/tool/selector.py
@@ -123,6 +123,11 @@ def add_common_flags(args: ArgumentParser) -> None:
         help="When true do not include Secrets to reduce output size and randomness",
     )
     args.add_argument(
+        "--skip-kinds",
+        type=lambda x: x.split(","),
+        help="A comma separated list of CRDs to omit from the output.",
+    )
+    args.add_argument(
         "--kustomize-build-flags",
         type=str,
         default="",
@@ -166,6 +171,7 @@ def build_ks_selector(  # type: ignore[no-untyped-def]
     selector.kustomization.label_selector = kwargs["label_selector"]
     selector.kustomization.skip_crds = kwargs["skip_crds"]
     selector.kustomization.skip_secrets = kwargs["skip_secrets"]
+    selector.kustomization.skip_kinds = kwargs["skip_kinds"]
     return selector
 
 
@@ -197,6 +203,7 @@ def build_hr_selector(  # type: ignore[no-untyped-def]
     selector.helm_release.label_selector = kwargs["label_selector"]
     selector.helm_release.skip_crds = kwargs["skip_crds"]
     selector.helm_release.skip_secrets = kwargs["skip_secrets"]
+    selector.helm_release.skip_kinds = kwargs["skip_kinds"]
     selector.kustomization.name = None
     selector.kustomization.namespace = None
     return selector
@@ -228,6 +235,7 @@ def build_helm_options(**kwargs) -> helm.Options:  # type: ignore[no-untyped-def
     return helm.Options(
         skip_crds=kwargs["skip_crds"],
         skip_secrets=kwargs["skip_secrets"],
+        skip_kinds=kwargs["skip_kinds"],
         kube_version=kwargs.get("kube_version"),
         api_versions=kwargs.get("api_versions"),
         registry_config=kwargs.get("registry_config"),
@@ -255,6 +263,7 @@ def build_cluster_selector(  # type: ignore[no-untyped-def]
     selector.kustomization.label_selector = kwargs["label_selector"]
     selector.kustomization.skip_crds = kwargs["skip_crds"]
     selector.kustomization.skip_secrets = kwargs["skip_secrets"]
+    selector.kustomization.skip_kinds = kwargs["skip_kinds"]
     return selector
 
 


### PR DESCRIPTION
Example before and after usage:
```
$ flux-local build ks --path tests/testdata/cluster | kustomize cfg count
Certificate: 4
ClusterPolicy: 1
ConfigMap: 2
GitRepository: 1
HelmRelease: 3
HelmRepository: 3
Kustomization: 4
Namespace: 1
$ flux-local build ks --path tests/testdata/cluster --skip-kinds=ClusterPolicy,Certificate | kustomize cfg count
ConfigMap: 2
GitRepository: 1
HelmRelease: 3
HelmRepository: 3
Kustomization: 4
Namespace: 1
```

Fixes #824