### PR TITLE
Remove unnecessary slugify dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ nest_asyncio==1.6.0
 pytest==8.3.5
 pytest-asyncio==0.25.3
 pytest-cov==6.0.0
-python-slugify==8.0.4
 PyYAML==6.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ python_requires = >=3.10
 install_requires =
   aiofiles>=22.1.0
   nest_asyncio>=1.5.6
-  python-slugify>=8.0.0
   GitPython>=3.1.30
   PyYAML>=6.0
   mashumaro>=3.12


### PR DESCRIPTION
Perhaps it's used in github actions eg by cruft, but the actual package doesn't need this so let's run lean.


#### Research
I looked at some git history and this was an early addition which I think is not used by anything. I didn't check if anything else needs it. I guess pytest shouldn't really be there either but that's a different story. I have not really ran the github actions in my fork but the tests in this repo should surface any issues I guess!
The motivation behind removing slugify is because it is installing unidecode which is GPL, so it restricts commercial usage. Feel free to close if I am wrong about this!