### PR TITLE
Fix "RuntimeError: Event loop is closed"

### DIFF
--- a/flux_local/tool/flux_local.py
+++ b/flux_local/tool/flux_local.py
@@ -58,7 +58,7 @@ def main() -> None:
 
     action = args.cls()
     try:
-        asyncio.run(action.run(**vars(args)))
+        asyncio.get_event_loop().run_until_complete(action.run(**vars(args)))
     except FluxException as err:
         if args.log_level == "DEBUG":
             traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
Fix "RuntimeError: Event loop is closed" by running the event loop until it closes.