### PR TITLE
Add a foundational storage module

### DIFF
--- a/flux_local/store/__init__.py
+++ b/flux_local/store/__init__.py
@@ -1,0 +1,23 @@
+"""
+The store module provides a central, type-safe repository for tracking the state, definitions,
+and artifacts of Kubernetes custom resources (CRs) during a flux-local run.
+
+- Uses NamedResource as the key for all objects.
+- Stores values as dataclass instances from manifest.py for type safety.
+- Provides query and update APIs for controllers (e.g., SourceController, KustomizeController).
+
+This abstract interface allows for various implementations (in-memory, persistent, etc.).
+"""
+
+from .store import Store
+from .in_memory import InMemoryStore
+from .artifact import Artifact
+from .status import Status, StatusInfo
+
+__all__ = [
+    "Store",
+    "InMemoryStore",
+    "Artifact",
+    "Status",
+    "StatusInfo",
+]

--- a/flux_local/store/artifact.py
+++ b/flux_local/store/artifact.py
@@ -1,0 +1,10 @@
+"""Artifact representation."""
+
+from abc import ABC
+from dataclasses import dataclass
+
+
+@dataclass
+class Artifact(ABC):
+    path: str
+    revision: str

--- a/flux_local/store/in_memory.py
+++ b/flux_local/store/in_memory.py
@@ -1,0 +1,85 @@
+"""Module for in memory object store."""
+
+from typing import TypeVar
+from flux_local.manifest import NamedResource, BaseManifest
+from .artifact import Artifact
+from .status import Status, StatusInfo
+from .store import Store
+
+T = TypeVar("T", bound=BaseManifest)
+S = TypeVar("S", bound=Artifact)
+
+
+class InMemoryStore(Store):
+    """In-memory implementation of the Store interface.
+
+    Stores manifest objects, status, and artifacts keyed by NamedResource.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the iInMemoryStore."""
+        self._objects: dict[NamedResource, BaseManifest] = {}
+        self._status: dict[NamedResource, StatusInfo] = {}
+        self._artifacts: dict[NamedResource, Artifact] = {}
+
+    def add_object(self, obj: T) -> None:
+        """Add a manifest object to the store."""
+        if (
+            not hasattr(obj, "kind")
+            or not hasattr(obj, "namespace")
+            or not hasattr(obj, "name")
+        ):
+            raise ValueError("Object must have kind, namespace, and name attributes")
+        resource_id = NamedResource(obj.kind, getattr(obj, "namespace", None), obj.name)
+        self._objects[resource_id] = obj
+
+    def get_object(self, resource_id: NamedResource, cls: type[T]) -> T | None:
+        """Retrieve a manifest object by resource identity and type."""
+        obj = self._objects.get(resource_id)
+        if obj is not None:
+            if isinstance(obj, cls):
+                return obj
+            raise ValueError(
+                f"Object {resource_id.namespaced_name} is not of type {cls.__name__} (was {obj.__class__.__name__})"
+            )
+        return None
+
+    def update_status(
+        self, resource_id: NamedResource, status: Status, error: str | None = None
+    ) -> None:
+        """Update the processing status and optional error message for a resource."""
+        self._status[resource_id] = StatusInfo(status=status, error=error)
+
+    def get_status(self, resource_id: NamedResource) -> StatusInfo | None:
+        """Retrieve the processing status for a resource."""
+        status_info = self._status.get(resource_id)
+        if status_info:
+            return status_info
+        return None
+
+    def set_artifact(self, resource_id: NamedResource, artifact: S) -> None:
+        """Store artifact information (e.g., source path, revision, rendered manifests) for a resource."""
+        if not isinstance(artifact, Artifact):
+            raise ValueError(
+                f"Artifact {resource_id.namespaced_name} is not of type {Artifact.__name__} (was {artifact.__class__.__name__})"
+            )
+        self._artifacts[resource_id] = artifact
+
+    def get_artifact(self, resource_id: NamedResource, cls: type[S]) -> S | None:
+        """Retrieve artifact information for a resource."""
+        artifact = self._artifacts.get(resource_id)
+        if artifact is not None:
+            if not isinstance(artifact, cls):
+                raise ValueError(
+                    f"Artifact {resource_id.namespaced_name} is not of type {cls.__name__} (was {artifact.__class__.__name__})"
+                )
+            return artifact
+        return None
+
+    def list_objects(self, kind: str | None = None) -> list[BaseManifest]:
+        """List all manifest objects in the store, optionally filtered by kind."""
+        if kind is None:
+            return list(self._objects.values())
+        return [
+            obj for obj in self._objects.values() if getattr(obj, "kind", None) == kind
+        ]

--- a/flux_local/store/status.py
+++ b/flux_local/store/status.py
@@ -1,0 +1,20 @@
+"""Status information for a resource."""
+
+from enum import StrEnum
+from dataclasses import dataclass
+
+
+class Status(StrEnum):
+    """Processing status for a resource."""
+
+    PENDING = "Pending"
+    READY = "Ready"
+    FAILED = "Failed"
+
+
+@dataclass
+class StatusInfo:
+    """Processing status and optional error message for a resource."""
+
+    status: Status
+    error: str | None = None

--- a/flux_local/store/store.py
+++ b/flux_local/store/store.py
@@ -1,0 +1,44 @@
+"""Store module for holding state while visiting resources."""
+
+from abc import ABC, abstractmethod
+from typing import TypeVar
+from flux_local.manifest import NamedResource, BaseManifest
+from .artifact import Artifact
+from .status import Status, StatusInfo
+
+T = TypeVar("T", bound=BaseManifest)
+S = TypeVar("S", bound=Artifact)
+
+
+class Store(ABC):
+    """Abstract base class for the central object type-safe object store."""
+
+    @abstractmethod
+    def add_object(self, obj: T) -> None:
+        """Add a manifest object to the store."""
+
+    @abstractmethod
+    def get_object(self, resource_id: NamedResource, cls: type[T]) -> T | None:
+        """Retrieve a manifest object by resource identity and type."""
+
+    @abstractmethod
+    def update_status(
+        self, resource_id: NamedResource, status: Status, error: str | None = None
+    ) -> None:
+        """Update the processing status and optional error message for a resource."""
+
+    @abstractmethod
+    def get_status(self, resource_id: NamedResource) -> StatusInfo | None:
+        """Retrieve the processing status for a resource."""
+
+    @abstractmethod
+    def set_artifact(self, resource_id: NamedResource, artifact: S) -> None:
+        """Store artifact information (e.g., source path, revision, rendered manifests) for a resource."""
+
+    @abstractmethod
+    def get_artifact(self, resource_id: NamedResource, cls: type[S]) -> S | None:
+        """Retrieve artifact information for a resource."""
+
+    @abstractmethod
+    def list_objects(self, kind: str | None = None) -> list[BaseManifest]:
+        """List all manifest objects in the store, optionally filtered by kind."""

--- a/tests/store/test_in_memory.py
+++ b/tests/store/test_in_memory.py
@@ -1,0 +1,91 @@
+import pytest
+from flux_local.store import InMemoryStore, Status, StatusInfo
+from flux_local.store.artifact import Artifact
+from flux_local.manifest import NamedResource, BaseManifest
+from dataclasses import dataclass
+
+
+@dataclass
+class DummyManifest(BaseManifest):
+    kind: str
+    namespace: str
+    name: str
+    value: int
+
+
+@dataclass
+class DummyArtifact(Artifact):
+    path: str
+    revision: str
+
+
+@pytest.fixture
+def store() -> InMemoryStore:
+    return InMemoryStore()
+
+
+def test_add_and_get_object(store: InMemoryStore) -> None:
+    """Test adding and retrieving a manifest object."""
+    obj = DummyManifest(kind="TestKind", namespace="ns", name="foo", value=42)
+    rid = NamedResource("TestKind", "ns", "foo")
+    store.add_object(obj)
+    result = store.get_object(rid, DummyManifest)
+    assert result == obj
+
+    class NotDummy(BaseManifest):
+        pass
+
+    with pytest.raises(
+        ValueError, match=r"Object ns/foo is not of type NotDummy \(was DummyManifest\)"
+    ):
+        store.get_object(rid, NotDummy)
+
+
+def test_update_and_get_status(store: InMemoryStore) -> None:
+    """Test updating and retrieving a status."""
+    rid = NamedResource("TestKind", "ns", "bar")
+    store.update_status(rid, Status.PENDING)
+    assert store.get_status(rid) == StatusInfo(status=Status.PENDING)
+    store.update_status(rid, Status.FAILED, error="boom")
+    assert store.get_status(rid) == StatusInfo(status=Status.FAILED, error="boom")
+    store.update_status(rid, Status.READY)
+    assert store.get_status(rid) == StatusInfo(status=Status.READY)
+
+
+def test_set_and_get_artifact(store: InMemoryStore) -> None:
+    """Test setting and retrieving an artifact."""
+    rid = NamedResource("TestKind", "ns", "baz")
+    artifact = DummyArtifact(path="/tmp/foo", revision="abc123")
+    store.set_artifact(rid, artifact)
+    result = store.get_artifact(rid, DummyArtifact)
+    assert result == artifact
+
+    # Wrong type returns None
+    class NotDummyArtifact(Artifact):
+        pass
+
+    with pytest.raises(
+        ValueError,
+        match=r"Artifact ns/baz is not of type NotDummyArtifact \(was DummyArtifact\)",
+    ):
+        store.get_artifact(rid, NotDummyArtifact)
+
+
+def test_list_objects(store: InMemoryStore) -> None:
+    """Test listing objects."""
+    obj1 = DummyManifest(kind="KindA", namespace="ns", name="foo", value=1)
+    obj2 = DummyManifest(kind="KindB", namespace="ns", name="bar", value=2)
+    obj3 = DummyManifest(kind="KindA", namespace="ns", name="baz", value=3)
+    store.add_object(obj1)
+    store.add_object(obj2)
+    store.add_object(obj3)
+    all_objs = store.list_objects()
+    assert sorted(all_objs, key=lambda x: x.name) == sorted(  # type: ignore[attr-defined]
+        [obj1, obj2, obj3], key=lambda x: x.name
+    )
+    kind_a_objs = store.list_objects(kind="KindA")
+    assert sorted(kind_a_objs, key=lambda x: x.name) == sorted(  # type: ignore[attr-defined]
+        [obj1, obj3], key=lambda x: x.name
+    )
+    kind_b_objs = store.list_objects(kind="KindB")
+    assert kind_b_objs == [obj2]


### PR DESCRIPTION
The store module provides a central, type-safe repository for tracking the state, definitions,
and artifacts of Kubernetes custom resources (CRs) during a flux-local run.
- Uses NamedResource as the key for all objects.
- Stores values as dataclass instances from manifest.py for type safety.
- Provides query and update APIs for controllers (e.g., SourceController, KustomizeController).

This abstract interface allows for various implementations (in-memory, persistent, etc.).