### PR TITLE
pin oras in requirements.txt (avoid bug in oras 0.2.34)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-asyncio==1.0.0
 pytest-cov==6.1.1
 PyYAML==6.0.2
 python-slugify==8.0.4
+oras==0.2.33


### PR DESCRIPTION
This addresses https://github.com/allenporter/flux-local/issues/942 which is an issue in oras==0.2.34

https://github.com/oras-project/oras-py/pull/208

~Considered pinning the version, but it seems oras releases quite frequently, so hopefully the fix will be in the next release.~

The more I look at this, the more I think `oras` should be pinned and have renovate update it. This would have been prevented by the failed run, similar to https://github.com/allenporter/flux-local/pull/941