### PR TITLE
Fixes for new Helm Controller reconciliation

### DIFF
--- a/flux_local/helm_controller/controller.py
+++ b/flux_local/helm_controller/controller.py
@@ -154,16 +154,16 @@ class HelmReleaseController:
         """
         _LOGGER.info("Reconciling HelmRelease %s", resource_id)
 
-        if self._need_update:
-            _LOGGER.info("Updating Helm repositories")
-            await self.helm.update()
-            self._need_update = False
-
         # Update status to processing
         self.store.update_status(resource_id, Status.PENDING)
 
         # Wait for dependencies to be ready
         await self.wait_for_dependencies(helm_release)
+
+        if self._need_update:
+            _LOGGER.info("Updating Helm repositories")
+            await self.helm.update()
+            self._need_update = False
 
         # TODO: Exercise ValuesFrom logic
 

--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -51,6 +51,7 @@ HELM_RELEASE = "HelmRelease"
 HELM_REPO_KIND = "HelmRepository"
 HELM_CHART = "HelmChart"
 GIT_REPOSITORY = "GitRepository"
+HELM_REPOSITORY = "HelmRepository"
 OCI_REPOSITORY = "OCIRepository"
 KUSTOMIZE_KIND = "Kustomization"
 
@@ -983,6 +984,8 @@ def parse_raw_obj(obj: dict[str, Any]) -> BaseManifest:
         return Kustomization.parse_doc(obj)
     if kind == HELM_RELEASE:
         return HelmRelease.parse_doc(obj)
+    if kind == HELM_REPOSITORY:
+        return HelmRepository.parse_doc(obj)
     if kind == GIT_REPOSITORY:
         return GitRepository.parse_doc(obj)
     if kind == OCI_REPOSITORY:

--- a/tests/kustomize_controller/__snapshots__/test_controller.ambr
+++ b/tests/kustomize_controller/__snapshots__/test_controller.ambr
@@ -3,6 +3,8 @@
   list([
     Kustomization(name='app', namespace='default', path='./app', helm_repos=[], oci_repos=[], helm_releases=[], config_maps=[], secrets=[], source_path=None, source_kind='GitRepository', source_name='git-repo', source_namespace='test-ns', target_namespace='default', contents={'apiVersion': 'kustomize.toolkit.fluxcd.io/v1', 'kind': 'Kustomization', 'metadata': {'name': 'app', 'namespace': 'default'}, 'spec': {'interval': '10m', 'targetNamespace': 'default', 'sourceRef': {'kind': 'GitRepository', 'name': 'git-repo', 'namespace': 'test-ns'}, 'path': './app'}}, images=None, postbuild_substitute=None, postbuild_substitute_from=None, depends_on=[], labels=None),
     ConfigMap(name='app-config', namespace='default', data={'key': 'value'}, binary_data=None),
+    HelmRepository(name='podinfo', namespace='default', url='oci://ghcr.io/stefanprodan/charts', repo_type='oci'),
+    HelmRelease(name='podinfo', namespace='default', chart=HelmChart(name='podinfo', version=None, repo_name='podinfo', repo_namespace='flux-system', repo_kind='HelmRepository'), target_namespace=None, values=None, values_from=None, images=None, labels={'kustomize.toolkit.fluxcd.io/name': 'app', 'kustomize.toolkit.fluxcd.io/namespace': 'default'}, disable_schema_validation=False, disable_openapi_validation=False),
   ])
 # ---
 # name: test_kustomization_with_oci_source
@@ -10,5 +12,7 @@
     OCIRepository(name='test-repo', namespace='test-ns', url='test-url', ref=None),
     Kustomization(name='app', namespace='default', path='./app', helm_repos=[], oci_repos=[], helm_releases=[], config_maps=[], secrets=[], source_path=None, source_kind='OCIRepository', source_name='test-repo', source_namespace='test-ns', target_namespace='default', contents={'apiVersion': 'kustomize.toolkit.fluxcd.io/v1', 'kind': 'Kustomization', 'metadata': {'name': 'app', 'namespace': 'default'}, 'spec': {'interval': '10m', 'targetNamespace': 'default', 'sourceRef': {'kind': 'OCIRepository', 'name': 'test-repo', 'namespace': 'test-ns'}, 'path': './app'}}, images=None, postbuild_substitute=None, postbuild_substitute_from=None, depends_on=[], labels=None),
     ConfigMap(name='app-config', namespace='default', data={'key': 'value'}, binary_data=None),
+    HelmRepository(name='podinfo', namespace='default', url='oci://ghcr.io/stefanprodan/charts', repo_type='oci'),
+    HelmRelease(name='podinfo', namespace='default', chart=HelmChart(name='podinfo', version=None, repo_name='podinfo', repo_namespace='flux-system', repo_kind='HelmRepository'), target_namespace=None, values=None, values_from=None, images=None, labels={'kustomize.toolkit.fluxcd.io/name': 'app', 'kustomize.toolkit.fluxcd.io/namespace': 'default'}, disable_schema_validation=False, disable_openapi_validation=False),
   ])
 # ---

--- a/tests/kustomize_controller/test_controller.py
+++ b/tests/kustomize_controller/test_controller.py
@@ -120,6 +120,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - config_map.yaml
+- helm_repo.yaml
+- helm_release.yaml
 """,
         encoding="utf-8",
     )
@@ -134,6 +136,42 @@ metadata:
   name: app-config
 data:
   key: value
+""",
+        encoding="utf-8",
+    )
+
+    helm_repo_path = app_dir / "helm_repo.yaml"
+    helm_repo_path.write_text(
+        """apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: flux-system
+spec:
+  interval: 5m
+  type: oci
+  url: oci://ghcr.io/stefanprodan/charts
+""",
+        encoding="utf-8",
+    )
+
+    helm_release_path = app_dir / "helm_release.yaml"
+    helm_release_path.write_text(
+        """
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: podinfo
+spec:
+  releaseName: podinfo
+  chart:
+    spec:
+      chart: podinfo
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+        namespace: flux-system
 """,
         encoding="utf-8",
     )


### PR DESCRIPTION
Fixes for new helm controller where they would get stuck because:
- Helm update happens before HelmReposistory objects are complete
- HelmRepository objects from `kustomize build` not applied to storage properly