### PR TITLE
fix: properly handle CRDs that are type Secret

### DIFF
--- a/flux_local/git_repo.py
+++ b/flux_local/git_repo.py
@@ -520,7 +520,7 @@ async def visit_kustomization(
             if doc.get("kind") == CONFIG_MAP_KIND
         ],
         secrets=[
-            Secret.parse_doc(doc) for doc in cfg_docs if doc.get("kind") == SECRET_KIND
+            Secret.parse_doc(doc) for doc in cfg_docs if doc.get("kind") == SECRET_KIND and doc.get("apiVersion") == "v1"
         ],
     )
 
@@ -709,7 +709,7 @@ async def build_kustomization(
             if doc.get("kind") == CONFIG_MAP_KIND
         ]
         kustomization.secrets = [
-            Secret.parse_doc(doc) for doc in docs if doc.get("kind") == SECRET_KIND
+            Secret.parse_doc(doc) for doc in docs if doc.get("kind") == SECRET_KIND and doc.get("apiVersion") == "v1"
         ]
 
 

--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -1018,7 +1018,7 @@ def parse_raw_obj(obj: dict[str, Any], *, wipe_secrets: bool = True) -> BaseMani
         return OCIRepository.parse_doc(obj)
     if kind == CONFIG_MAP_KIND:
         return ConfigMap.parse_doc(obj)
-    if kind == SECRET_KIND:
+    if kind == SECRET_KIND and api_version == "v1":
         return Secret.parse_doc(obj, wipe_secrets=wipe_secrets)
     return RawObject.parse_doc(obj)
 

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -359,3 +359,55 @@ async def test_helmrelease_label_selector() -> None:
         "app.kubernetes.io/name": "kubernetes-dashboard"
     }
     assert await get_hr() == []
+
+
+async def test_secret_crd_filtering() -> None:
+    """Test that CRDs with kind Secret but non-v1 apiVersion are not parsed as Secret objects."""
+    from flux_local.manifest import Kustomization, Secret, ConfigMap
+
+    # Create a test kustomization
+    kustomization = Kustomization(
+        name="test-ks",
+        namespace="default",
+        path="./test"
+    )
+
+    # Test documents with both v1 Secret and CRD Secret
+    docs = [
+        {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": "v1-secret", "namespace": "default"},
+            "data": {"key": "value"}
+        },
+        {
+            "apiVersion": "external-secrets.io/v1beta1",
+            "kind": "Secret",
+            "metadata": {"name": "external-secret", "namespace": "default"},
+            "spec": {"secretStoreRef": {"name": "vault", "kind": "SecretStore"}}
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "config", "namespace": "default"},
+            "data": {"key": "value"}
+        }
+    ]
+
+    # Apply the same logic as in build_kustomization
+    kustomization.config_maps = [
+        ConfigMap.parse_doc(doc)
+        for doc in docs
+        if doc.get("kind") == "ConfigMap"
+    ]
+    kustomization.secrets = [
+        Secret.parse_doc(doc) for doc in docs if doc.get("kind") == "Secret" and doc.get("apiVersion") == "v1"
+    ]
+
+    # Verify only v1 Secret is parsed as Secret object
+    assert len(kustomization.secrets) == 1
+    assert kustomization.secrets[0].name == "v1-secret"
+
+    # Verify ConfigMap is parsed correctly
+    assert len(kustomization.config_maps) == 1
+    assert kustomization.config_maps[0].name == "config"


### PR DESCRIPTION
When working with CRDs that have a type of `Secret` flux-local fails to build kustomizations. Currently the code assumes anything that is a Secret will be a member of the v1 api group, this instead adds a check to only treat things as a secret if they are in v1.