### PR TITLE
feat: add `EnvoyProxy` and `Plan` to supported image types

### DIFF
--- a/flux_local/image.py
+++ b/flux_local/image.py
@@ -26,6 +26,7 @@ KINDS = [
     "Prometheus",  # monitoring.coreos.com/v1
     "AutoscalingRunnerSet",  # actions.github.com/v1alpha1
     "EnvoyProxy", # gateway.envoyproxy.io/v1alpha1
+    "Plan", # upgrade.cattle.io/v1
 ]
 
 # Default image key for most object types.


### PR DESCRIPTION
```yaml
---
# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: EnvoyProxy
metadata:
  name: envoy-external
spec:
  logging:
    level:
      default: info
  provider:
    type: Kubernetes
    kubernetes:
      envoyDeployment:
        replicas: 2
        container:
          image: mirror.gcr.io/envoyproxy/envoy:v1.35.2
          resources:
            requests:
              cpu: 100m
            limits:
              memory: 1Gi
```

```yaml
---
# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/upgrade.cattle.io/plan_v1.json
apiVersion: upgrade.cattle.io/v1
kind: Plan
metadata:
  name: kubernetes
spec:
  # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
  version: v1.34.0
  concurrency: 1
  exclusive: true
  serviceAccountName: system-upgrade-controller
  secrets:
    - name: system-upgrade-controller
      path: /var/run/secrets/talos.dev
      ignoreUpdates: true
  nodeSelector:
    matchExpressions:
      - key: node-role.kubernetes.io/control-plane
        operator: Exists
  upgrade:
    image: ghcr.io/siderolabs/talosctl:v1.11.1
    args:
      - --nodes=$(SYSTEM_UPGRADE_NODE_NAME)
      - upgrade-k8s
      - --to=$(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)

```