### PR TITLE
feat: add --ignore-paths support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ metadata.labels.helm.sh/chart  (PersistentVolumeClaim/default/hajimari-data)
     + hajimari-2.0.1
 ```
 
+Ignore specific paths
+
+You can exclude non-Kubernetes or otherwise irrelevant files and directories during
+diff with the `--ignore-paths` flag. Patterns are `.gitignore`-style and may be
+comma-separated. A trailing slash matches a directory and all its contents (e.g., `.github/`).
+
+```bash
+$ flux-local diff ks apps --path clusters/prod --ignore-paths ".github/,scripts/"
+```
+
 
 ### flux-local test
 
@@ -214,6 +224,16 @@ You may also validate `HelmRelease` objects can be templated properly with the `
 flag. This will run `kustomize build` then run `helm template` on all the `HelmRelease` objects
 found.
 
+Ignore specific paths
+
+Use `--ignore-paths` to omit directories/files from discovery and build when running tests.
+Patterns are `.gitignore`-style and may be comma-separated. A trailing slash matches a directory
+and all its contents (e.g., `.github/`).
+
+```bash
+$ flux-local test --path clusters/prod --ignore-paths ".github/,local/"
+```
+
 ## GitHub Action
 
 You may use `flux-local` as a github action to verify the health of the cluster on changes
@@ -236,6 +256,19 @@ helm release expansion enabled.
     enable-helm: true
 ```
 
+Ignore paths during builds
+
+You can exclude directories/files from discovery and builds using `.gitignore`-style
+patterns via the `ignore-paths` input (comma-separated, relative to `path`). A trailing
+slash matches a directory and all its contents (e.g., `.github/`).
+
+```yaml
+- uses: allenporter/flux-local/action/test@4.3.1
+  with:
+    path: clusters/prod
+    ignore-paths: ".github/,scripts/,local/"
+```
+
 ### diff action
 
 The `diff` action will show you the final diffs of `Kustomization` or `HelmRelease`
@@ -254,6 +287,7 @@ This is an example that diffs a `HelmRelease`:
     live-branch: main
     path: clusters/prod
     resource: helmrelease
+    ignore-paths: ".github/,scripts/"
 - name: PR Comments
   uses: mshick/add-pr-comment@v2
   if: ${{ steps.diff.outputs.diff != '' }}
@@ -291,6 +325,7 @@ jobs:
           live-branch: main
           path: ${{ matrix.cluster_path }}
           resource: ${{ matrix.resource }}
+          ignore-paths: ".github/,scripts/"
       - name: PR Comments
         uses: mshick/add-pr-comment@v2
         if: ${{ steps.diff.outputs.diff != '' }}

--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -40,6 +40,9 @@ inputs:
   kustomize-build-flags:
     description: Additional flags to pass to kustomize build
     default: ""
+  ignore-paths:
+    description: Comma-separated .gitignore-style patterns to ignore during build
+    default: ""
   sources:
     description: GitRepository or OCIRepository to include with optional source mappings like `flux-system` or `cluster=./kubernetes/`
     default: ""
@@ -112,6 +115,7 @@ runs:
             --limit-bytes ${{ inputs.limit-bytes }} \
             --all-namespaces \
             --kustomize-build-flags="${{ inputs.kustomize-build-flags }}" \
+            --ignore-paths "${{ inputs.ignore-paths }}" \
             --sources "${{ inputs.sources }}" \
             --output-file diff.patch \
             ${extra_flags}

--- a/action/test/action.yml
+++ b/action/test/action.yml
@@ -22,6 +22,9 @@ inputs:
   kustomize-build-flags:
     description: Additional flags to pass to kustomize build
     default: ""
+  ignore-paths:
+    description: Comma-separated .gitignore-style patterns to ignore during build
+    default: ""
   sources:
     description: GitRepository or OCIRepository to include with optional source mappings like `flux-system` or `cluster=./kubernetes/`
     default: ""
@@ -62,6 +65,7 @@ runs:
           --${{ inputs.enable-helm != 'true' && 'no-' || '' }}enable-helm \
           --api-versions "${{ inputs.api-versions }}" \
           --kustomize-build-flags="${{ inputs.kustomize-build-flags }}" \
+          --ignore-paths "${{ inputs.ignore-paths }}" \
           --sources "${{ inputs.sources }}" \
           --path ${{ inputs.path }} \
           --verbosity ${{ inputs.debug != 'true' && '0' || '1' }} \

--- a/flux_local/kustomize_controller/controller.py
+++ b/flux_local/kustomize_controller/controller.py
@@ -23,7 +23,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any, cast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from flux_local.store import Store, Status, Artifact
 from flux_local.source_controller.artifact import GitArtifact, OCIArtifact
@@ -63,6 +63,7 @@ class KustomizationControllerConfig:
     """Configuration for the KustomizationController."""
 
     wipe_secrets: bool = True
+    ignore_paths: list[str] = field(default_factory=list)
 
 
 class KustomizationController:
@@ -388,7 +389,9 @@ class KustomizationController:
 
         try:
             path = Path(source_path)
-            kustomize = flux_build(kustomization, path)
+            kustomize = flux_build(
+                kustomization, path, ignore_paths=self._config.ignore_paths
+            )
             objects = await kustomize.objects(
                 target_namespace=kustomization.target_namespace
             )

--- a/flux_local/tool/build_kustomization.py
+++ b/flux_local/tool/build_kustomization.py
@@ -144,6 +144,9 @@ class BuildKustomizationAction:
         # Disable Helm for ks-only build
         config = OrchestratorConfig(enable_helm=False)
         config.kustomization_controller_config.wipe_secrets = kwargs["wipe_secrets"]
+        config.kustomization_controller_config.ignore_paths = git_repo.flatten_ignore_paths(
+            kwargs.get("ignore_paths", [])
+        )
         config.read_action_config.wipe_secrets = kwargs["wipe_secrets"]
         config.source_controller_config.enable_oci = kwargs["enable_oci"]
         orchestrator = Orchestrator(store, config)

--- a/flux_local/tool/diagnostics.py
+++ b/flux_local/tool/diagnostics.py
@@ -38,6 +38,15 @@ class DiagnosticsAction:
             default=None,
             nargs="?",
         )
+        args.add_argument(
+            "--ignore-paths",
+            action="append",
+            default=[],
+            help=(
+                "Comma-separated .gitignore-style patterns to ignore while scanning. "
+                "May be supplied multiple times."
+            ),
+        )
         args.set_defaults(cls=cls)
         return args
 
@@ -50,7 +59,7 @@ class DiagnosticsAction:
 
         # Parse directories to ignore from `.krmignore`
         krmignore = pathlib.Path(path) / ".krmignore"
-        ignoredirs = list(IGNORE_DIRS)
+        ignoredirs = list(IGNORE_DIRS) + kwargs.get("ignore_paths", [])
         if krmignore.exists():
             with krmignore.open() as fd:
                 ignoredirs.extend(

--- a/flux_local/tool/selector.py
+++ b/flux_local/tool/selector.py
@@ -139,6 +139,15 @@ def add_common_flags(args: ArgumentParser) -> None:
         default="",
         help="If present, additional flags to pass to `kustomize build`",
     )
+    args.add_argument(
+        "--ignore-paths",
+        action="append",
+        default=[],
+        help=(
+            "Comma-separated .gitignore-style patterns to ignore when building. "
+            "Passed through to `flux build --ignore-paths`. May be set multiple times."
+        ),
+    )
 
 
 def add_ks_selector_flags(args: ArgumentParser) -> None:
@@ -157,7 +166,9 @@ def options(  # type: ignore[no-untyped-def]
     kustomize_build_flags: str | None, **kwargs
 ) -> git_repo.Options:
     """Create an Options object based on flags."""
-    options = git_repo.Options()
+    options = git_repo.Options(
+        ignore_paths=git_repo.flatten_ignore_paths(kwargs.get("ignore_paths", []))
+    )
     options.kustomize_flags = shlex.split(kustomize_build_flags or "")
     options.skip_kustomize_path_validation = kwargs.get(
         "skip_invalid_kustomization_paths", False

--- a/flux_local/tool/test.py
+++ b/flux_local/tool/test.py
@@ -144,7 +144,9 @@ class KustomizationTest(pytest.Item):
     async def async_runtest(self) -> None:
         """Run the Kustomizations test."""
         cmd = await kustomize.flux_build(
-            self.kustomization, Path(self.kustomization.path)
+            self.kustomization,
+            Path(self.kustomization.path),
+            ignore_paths=self.test_config.options.ignore_paths,
         ).stash()
         await cmd.objects()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pytest>=7.2.1",
   "pytest-asyncio>=0.20.3",
   "python-slugify>=8.0.1",
+  "pathspec>=0.12.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-cov==7.0.0
 PyYAML==6.0.3
 python-slugify==8.0.4
 oras==0.2.38
+pathspec==0.12.1

--- a/tests/source_controller/test_controller.py
+++ b/tests/source_controller/test_controller.py
@@ -49,7 +49,7 @@ def git_repo_dir_fixture(git_repo_tmp_dir: Path) -> Path:
     repo_path.mkdir()
 
     # Initialize git repository
-    repo = git.Repo.init(repo_path)
+    repo = git.Repo.init(repo_path, initial_branch='master')
     repo.config_writer().set_value("user", "name", "myusername").release()
     repo.config_writer().set_value("user", "email", "myemail").release()
 

--- a/tests/test_kustomize.py
+++ b/tests/test_kustomize.py
@@ -126,6 +126,7 @@ async def test_flux_build_path_is_not_dir() -> None:
     cmd = kustomize.flux_build(
         manifest.Kustomization(name="example", path="./", namespace="flux-system"),
         Path(TESTDATA_DIR) / "does-not-exist",
+        ignore_paths=[],
     )
     with pytest.raises(exceptions.FluxException, match="not a directory"):
         await cmd.objects()
@@ -142,6 +143,6 @@ async def test_flux_build() -> None:
     )
     assert len(docs) == 2
     ks = manifest.Kustomization.parse_doc(docs[1])
-    cmd = kustomize.flux_build(ks, Path(ks.path))
+    cmd = kustomize.flux_build(ks, Path(ks.path), ignore_paths=[])
     result = await cmd.run()
     assert "GitRepository" in result

--- a/tests/testdata/cluster_ignore_junk/apps/base/podinfo/cm.yaml
+++ b/tests/testdata/cluster_ignore_junk/apps/base/podinfo/cm.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+  namespace: default
+data:
+  key: value

--- a/tests/testdata/cluster_ignore_junk/apps/base/podinfo/kustomization.yaml
+++ b/tests/testdata/cluster_ignore_junk/apps/base/podinfo/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cm.yaml

--- a/tests/testdata/cluster_ignore_junk/clusters/prod/flux-system/kustomization.yaml
+++ b/tests/testdata/cluster_ignore_junk/clusters/prod/flux-system/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./tests/testdata/cluster_ignore_junk/apps/base/podinfo
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default

--- a/tests/testdata/cluster_ignore_junk/junk/bad.yaml
+++ b/tests/testdata/cluster_ignore_junk/junk/bad.yaml
@@ -1,0 +1,3 @@
+---
+- foo: bar
+- baz: qux

--- a/tests/tool/test_diagnostics.py
+++ b/tests/tool/test_diagnostics.py
@@ -12,7 +12,9 @@ from . import run_command
 
 async def test_diagnostics(snapshot: SnapshotAssertion) -> None:
     """Test test get ks commands."""
-    result = await run_command(["diagnostics"])
+    result = await run_command(
+        ["diagnostics", "--ignore-paths", "tests/testdata/cluster_ignore_junk/junk"]
+    )
     assert result == snapshot
 
 


### PR DESCRIPTION
Add `--ignore-paths` flag to CLI and actions.

Some repositories may contain yaml files that are not kustomize or cluster resources. Allow skipping those paths.

Fixes: #211