### PR TITLE
Fix arguments to BooleanOptionalAction

### DIFF
--- a/flux_local/tool/build.py
+++ b/flux_local/tool/build.py
@@ -44,7 +44,6 @@ class BuildAllAction:
         )
         args.add_argument(
             "--enable-helm",
-            type=bool,
             action=BooleanOptionalAction,
             help="Enable use of HelmRelease inflation",
         )

--- a/flux_local/tool/build_kustomization.py
+++ b/flux_local/tool/build_kustomization.py
@@ -81,14 +81,12 @@ class BuildKustomizationAction:
         )
         args.add_argument(
             "--wipe-secrets",
-            type=str,
             default=True,
             action=BooleanOptionalAction,
             help="Wipe secrets from the output",
         )
         args.add_argument(
             "--enable-oci",
-            type=str,
             default=False,
             action=BooleanOptionalAction,
             help="Enable OCI repository sources",

--- a/flux_local/tool/get.py
+++ b/flux_local/tool/get.py
@@ -168,14 +168,12 @@ class GetClusterAction:
         selector.add_cluster_selector_flags(args)
         args.add_argument(
             "--enable-images",
-            type=str,
             default=False,
             action=BooleanOptionalAction,
             help="Output container images when traversing the cluster",
         )
         args.add_argument(
             "--only-images",
-            type=str,
             default=False,
             action=BooleanOptionalAction,
             help="Output only container images when traversing the cluster",

--- a/flux_local/tool/selector.py
+++ b/flux_local/tool/selector.py
@@ -85,7 +85,6 @@ def add_selector_flags(args: ArgumentParser) -> None:
     args.add_argument(
         "--all-namespaces",
         "-A",
-        type=bool,
         default=False,
         action=BooleanOptionalAction,
         help="List the requested objects across all namespaces.",
@@ -110,14 +109,12 @@ def add_common_flags(args: ArgumentParser) -> None:
     """Add flags that are common to selectors and other command types."""
     args.add_argument(
         "--skip-crds",
-        type=str,
         default=True,
         action=BooleanOptionalAction,
         help="When true do not include CRDs to reduce output size",
     )
     args.add_argument(
         "--skip-secrets",
-        type=str,
         default=True,
         action=BooleanOptionalAction,
         help="When true do not include Secrets to reduce output size and randomness",
@@ -235,7 +232,6 @@ def add_helm_options_flags(args: ArgumentParser) -> None:
     )
     args.add_argument(
         "--skip-invalid-helm-release-paths",
-        type=bool,
         default=True,
         action=BooleanOptionalAction,
         help="When true, skip helm releases with local paths that do not exist",

--- a/flux_local/tool/test.py
+++ b/flux_local/tool/test.py
@@ -354,7 +354,6 @@ class TestAction:
         )
         args.add_argument(
             "--enable-helm",
-            type=bool,
             action=BooleanOptionalAction,
             help="Enable use of HelmRelease inflation",
         )


### PR DESCRIPTION
Fix arguments to BooleanOptionalAction that are not needed. These break in python 3.14.