### PR TITLE
feat(gha): add skip-invalid-kustomization-paths to github action

### DIFF
--- a/action/diff/action.yml
+++ b/action/diff/action.yml
@@ -50,6 +50,9 @@ inputs:
   registry-config:
     description: Path to registry config for OCIRepository, formatted as a docker config JSON
     default: ""
+  skip-invalid-kustomization-paths:
+    description: When true, does not validate kustomization paths exist
+    default: false
 outputs:
   diff:
     description: Output of the diff command or empty if there is no diff
@@ -109,6 +112,7 @@ runs:
             --strip-attrs "${{ inputs.strip-attrs }}" \
             --${{ inputs.skip-crds != 'true' && 'no-' || '' }}skip-crds \
             --${{ inputs.skip-secrets != 'true' && 'no-' || '' }}skip-secrets \
+            --${{ inputs.skip-invalid-kustomization-paths != 'true' && 'no-' || '' }}skip-invalid-kustomization-paths \
             --limit-bytes ${{ inputs.limit-bytes }} \
             --all-namespaces \
             --kustomize-build-flags="${{ inputs.kustomize-build-flags }}" \

--- a/action/test/action.yml
+++ b/action/test/action.yml
@@ -28,6 +28,9 @@ inputs:
   registry-config:
     description: Path to registry config for OCIRepository, formatted as a docker config JSON
     default: ""
+  skip-invalid-kustomization-paths:
+    description: When true, does not validate kustomization paths exist
+    default: false
 runs:
   using: "composite"
   steps:
@@ -65,5 +68,6 @@ runs:
           --sources "${{ inputs.sources }}" \
           --path ${{ inputs.path }} \
           --verbosity ${{ inputs.debug != 'true' && '0' || '1' }} \
-          --registry-config "${{ inputs.registry-config }}"
+          --registry-config "${{ inputs.registry-config }}" \
+          --${{ inputs.skip-invalid-kustomization-paths != 'true' && 'no-' || '' }}skip-invalid-kustomization-paths
       shell: bash


### PR DESCRIPTION
Adding `--skip-invalid-kustomization-paths` to the Github Action since it currently is not exposed. This allows me a workaround for #1068.