### PR TITLE
Update devcontainer to mcr.microsoft.com/devcontainers/python:3.14-bookworm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,14 @@
 # Docker environment for local development in devcontainer
 
-FROM ubuntu:noble-20260113
+FROM mcr.microsoft.com/devcontainers/python:3.14-bookworm
 
 RUN apt-get update --fix-missing && \
     apt-get upgrade -y && \
     apt-get install -y --fix-missing \
         curl \
         unzip \
-        software-properties-common \
         vim \
-        git \
-        python3-pip
+        git
 
 COPY --from=registry.k8s.io/kubectl:v1.35.0             /bin/kubectl                     /usr/local/bin/kubectl
 COPY --from=registry.k8s.io/kustomize/kustomize:v5.8.0  /app/kustomize                   /usr/local/bin/kustomize

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -13,6 +13,8 @@ if command -v uv >/dev/null 2>&1; then
   uv pip install -r requirements_dev.txt
 elif command -v python3 >/dev/null 2>&1; then
   echo "==> Using pip for installation..."
+  python3 -m venv .venv
+  source .venv/bin/activate
   python3 -m pip install --upgrade pip
   python3 -m pip install -e ".[all]"
   python3 -m pip install -r requirements_dev.txt


### PR DESCRIPTION
Goal is to move to a newer python version and potentially lighter weight image.