### PR TITLE
Add tests for helm template flags

### DIFF
--- a/.krmignore
+++ b/.krmignore
@@ -1,3 +1,4 @@
 .git
 local-charts
 tests/testdata/cluster9/local-charts
+tests/testdata/cluster12/local-charts

--- a/.yaml-lint.yaml
+++ b/.yaml-lint.yaml
@@ -2,6 +2,7 @@
 ignore: |
   venv
   tests/testdata/cluster9/local-charts/
+  tests/testdata/cluster12/local-charts/
 extends: default
 rules:
   truthy:

--- a/tests/testdata/cluster12/apps/flag-fixture/helm-release.yaml
+++ b/tests/testdata/cluster12/apps/flag-fixture/helm-release.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: flag-fixture
+  namespace: default
+spec:
+  interval: 3h
+  chart:
+    spec:
+      chart: ./tests/testdata/cluster12/local-charts/flag-fixture
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  releaseName: flag-fixture

--- a/tests/testdata/cluster12/apps/flag-fixture/kustomization.yaml
+++ b/tests/testdata/cluster12/apps/flag-fixture/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/tests/testdata/cluster12/apps/kustomization.yaml
+++ b/tests/testdata/cluster12/apps/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flag-fixture

--- a/tests/testdata/cluster12/cluster/apps.yaml
+++ b/tests/testdata/cluster12/cluster/apps.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./tests/testdata/cluster12/apps
+  prune: true
+  wait: true
+  timeout: 5m0s

--- a/tests/testdata/cluster12/cluster/flux-system/gotk-sync.yaml
+++ b/tests/testdata/cluster12/cluster/flux-system/gotk-sync.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/allenporter/flux-local
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./tests/testdata/cluster12/cluster/
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/tests/testdata/cluster12/cluster/flux-system/kustomization.yaml
+++ b/tests/testdata/cluster12/cluster/flux-system/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gotk-sync.yaml

--- a/tests/testdata/cluster12/local-charts/flag-fixture/Chart.yaml
+++ b/tests/testdata/cluster12/local-charts/flag-fixture/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: flag-fixture
+description: Test chart for build hr flag coverage
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/tests/testdata/cluster12/local-charts/flag-fixture/crds/flagtests.example.com.yaml
+++ b/tests/testdata/cluster12/local-charts/flag-fixture/crds/flagtests.example.com.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: flagtests.example.com
+spec:
+  group: example.com
+  names:
+    kind: FlagTest
+    listKind: FlagTestList
+    plural: flagtests
+    singular: flagtest
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/tests/testdata/cluster12/local-charts/flag-fixture/templates/configmap.yaml
+++ b/tests/testdata/cluster12/local-charts/flag-fixture/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mode
+  namespace: {{ .Release.Namespace }}
+data:
+  lifecycle: {{ if .Release.IsUpgrade }}upgrade{{ else }}install{{ end }}
+  chart: {{ .Chart.Name }}

--- a/tests/testdata/cluster12/local-charts/flag-fixture/templates/service.yaml
+++ b/tests/testdata/cluster12/local-charts/flag-fixture/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}

--- a/tests/testdata/cluster12/local-charts/flag-fixture/templates/serviceaccount.yaml
+++ b/tests/testdata/cluster12/local-charts/flag-fixture/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-runner
+  namespace: {{ .Release.Namespace }}

--- a/tests/testdata/cluster12/local-charts/flag-fixture/values.yaml
+++ b/tests/testdata/cluster12/local-charts/flag-fixture/values.yaml
@@ -1,0 +1,3 @@
+service:
+  port: 80
+  targetPort: 8080

--- a/tests/tool/__snapshots__/test_build_hr.ambr
+++ b/tests/tool/__snapshots__/test_build_hr.ambr
@@ -260,6 +260,161 @@
   
   '''
 # ---
+# name: test_build_hr[build-hr-flag-fixture-include-crds]
+  '''
+  ---
+  # Source: flag-fixture/crds/flagtests.example.com.yaml
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: flagtests.example.com
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  spec:
+    group: example.com
+    names:
+      kind: FlagTest
+      listKind: FlagTestList
+      plural: flagtests
+      singular: flagtest
+    scope: Namespaced
+    versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+  ---
+  # Source: flag-fixture/templates/serviceaccount.yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: flag-fixture-runner
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  ---
+  # Source: flag-fixture/templates/configmap.yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: flag-fixture-mode
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  data:
+    lifecycle: install
+    chart: flag-fixture
+  ---
+  # Source: flag-fixture/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: flag-fixture
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '3'
+      internal.config.kubernetes.io/index: '3'
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/name: flag-fixture
+    ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr-flag-fixture-show-only-multiple]
+  '''
+  ---
+  # Source: flag-fixture/templates/configmap.yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: flag-fixture-mode
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  data:
+    lifecycle: install
+    chart: flag-fixture
+  ---
+  # Source: flag-fixture/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: flag-fixture
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/name: flag-fixture
+    ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  
+  
+  '''
+# ---
+# name: test_build_hr[build-hr-flag-fixture-upgrade]
+  '''
+  ---
+  # Source: flag-fixture/templates/serviceaccount.yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: flag-fixture-runner
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '0'
+      internal.config.kubernetes.io/index: '0'
+  ---
+  # Source: flag-fixture/templates/configmap.yaml
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: flag-fixture-mode
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '1'
+      internal.config.kubernetes.io/index: '1'
+  data:
+    lifecycle: upgrade
+    chart: flag-fixture
+  ---
+  # Source: flag-fixture/templates/service.yaml
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: flag-fixture
+    namespace: default
+    annotations:
+      config.kubernetes.io/index: '2'
+      internal.config.kubernetes.io/index: '2'
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/name: flag-fixture
+    ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  
+  
+  '''
+# ---
 # name: test_build_hr[build-hr-single-cluster6]
   '''
   ---

--- a/tests/tool/test_build_hr.py
+++ b/tests/tool/test_build_hr.py
@@ -42,6 +42,36 @@ from . import run_command
                 "--skip-invalid-kustomization-paths",
             ]
         ),
+        (
+            [
+                "flag-fixture",
+                "-n",
+                "default",
+                "--path=tests/testdata/cluster12/cluster",
+                "--is-upgrade",
+            ]
+        ),
+        (
+            [
+                "flag-fixture",
+                "-n",
+                "default",
+                "--path=tests/testdata/cluster12/cluster",
+                "--show-only",
+                "templates/configmap.yaml",
+                "--show-only",
+                "templates/service.yaml",
+            ]
+        ),
+        (
+            [
+                "flag-fixture",
+                "-n",
+                "default",
+                "--path=tests/testdata/cluster12/cluster",
+                "--no-skip-crds",
+            ]
+        ),
     ],
     ids=[
         "build-hr",
@@ -52,6 +82,9 @@ from . import run_command
         "build-hr-single-cluster8",
         "build-hr-single-cluster9",
         "build-hr-cluster10-invalid-paths",
+        "build-hr-flag-fixture-upgrade",
+        "build-hr-flag-fixture-show-only-multiple",
+        "build-hr-flag-fixture-include-crds",
     ],
 )
 async def test_build_hr(args: list[str], snapshot: SnapshotAssertion) -> None:


### PR DESCRIPTION
hi, sorry i wasn't able to add the unit tests for the #1092 in time before the pr getting merged.

here are the unit tests for that the helm template args added [as you suggested](https://github.com/allenporter/flux-local/pull/1092#pullrequestreview-3933675765).

i added a new test cluster `cluster12`:
- it contains a simple `crd/` used for testing `--no-skip-crds`
- it contains three templates. to test `--show-only`, we attempts to only select two of the three templates in the test
- it also contains a template using `.Release.IsUpgrade` to conditionally render the template. we use this to test `--is-upgrade` flag