### PR TITLE
fix: guard strip_resource_attributes against non-dict spec.template

### DIFF
--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -1172,6 +1172,7 @@ def strip_resource_attributes(
     if (
         (spec := resource.get("spec"))
         and (templ := spec.get("template"))
+        and isinstance(templ, dict)
         and (meta := templ.get("metadata"))
     ):
         _strip_attrs(meta, strip_attributes)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -536,6 +536,27 @@ items: null
     )
 
 
+def test_strip_resource_attributes_string_template() -> None:
+    """Test strip_resource_attributes does not crash when spec.template is a string."""
+    resource = yaml.load(
+        """apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: my-database
+  namespace: default
+  labels:
+    app.kubernetes.io/version: 1.0.0
+spec:
+  name: mydb
+  template: template0
+""",
+        Loader=yaml.Loader,
+    )
+
+    strip_resource_attributes(resource, STRIP_ATTRIBUTES)
+    assert resource["spec"]["template"] == "template0"
+
+
 def test_strip_list_item_without_metdata() -> None:
     """Test corner cases of handling metadata."""
     resource = yaml.load(


### PR DESCRIPTION
## Summary

- Add `isinstance(templ, dict)` guard in `strip_resource_attributes()` before calling `templ.get("metadata")`, preventing `AttributeError` when `spec.template` is a non-dict value
- This mirrors the existing `isinstance(items, list)` guard for `List.items` in the same function
- Includes regression test with the CloudNativePG `Database` CRD scenario from the issue

Closes #986