### PR TITLE
fix: have renovate pin github actions digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     "regexManagers:dockerfileVersions",
+    "helpers:pinGitHubActionDigestsToSemver",
   ],
   "timezone": "America/Los_Angeles",
   "assignees": ["allenporter"],


### PR DESCRIPTION
This change tells renovate to fully pin `uses:` entries in actions workflows. This is good practice in general, but is especially important for the reusable actions defined in this repo as not pinning in those could open up users to a transient supply-chain attack.