### PR TITLE
fix: if oci digest is set, dont pass helm version

### DIFF
--- a/flux_local/helm.py
+++ b/flux_local/helm.py
@@ -156,6 +156,8 @@ def _chart_name(
                 f"HelmRelease {release.name}"
             )
         if isinstance(repo, OCIRepository):
+            if (digest := repo.digest) is not None:
+                return repo.url + "@" + digest
             return repo.url
         raise HelmException(
             f"HelmRelease {release.name} expected OCIRepository but got HelmRepository {repo.repo_name}"
@@ -433,7 +435,7 @@ class Helm:
                         release.chart.version,
                     ]
                 )
-            elif isinstance(repo, OCIRepository) and (oci_version := repo.version()):
+            elif isinstance(repo, OCIRepository) and (repo.digest is None) and (oci_version := repo.version()):
                 args.extend(
                     [
                         "--version",

--- a/flux_local/manifest.py
+++ b/flux_local/manifest.py
@@ -735,6 +735,13 @@ class OCIRepository(BaseManifest):
             secret_ref=secret_ref,
         )
 
+    @property
+    def digest(self) -> str | None:
+        """Return the digest of the OCI repository."""
+        if self.ref:
+            return self.ref.digest
+        return None
+
     def version(self) -> str | None:
         """Get the version of the OCI repository."""
         if self.ref is not None:

--- a/tests/kustomize_controller/conftest.py
+++ b/tests/kustomize_controller/conftest.py
@@ -3,7 +3,7 @@
 from typing import AsyncGenerator
 
 import pytest
-from flux_local.manifest import GitRepository, OCIRepository
+from flux_local.manifest import GitRepository, OCIRepository, OCIRepositoryRef
 from flux_local.store.in_memory import InMemoryStore
 from flux_local.kustomize_controller.controller import (
     KustomizationController,
@@ -48,4 +48,4 @@ class DummyOCIRepository(OCIRepository):
         self.namespace = namespace
         self.name = name
         self.url = f"oci://example.com/{namespace}/{name}"
-        self.digest = f"sha256:{name}"
+        self.ref = OCIRepositoryRef(f"sha256:{name}")

--- a/tests/testdata/cluster9/apps/podinfo/repository.yaml
+++ b/tests/testdata/cluster9/apps/podinfo/repository.yaml
@@ -12,6 +12,7 @@ spec:
   url: oci://ghcr.io/stefanprodan/charts/podinfo
   ref:
     tag: "6.7.1"
+    digest: sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391
   secretRef:
     name: podinfo-pull-secret
 ---

--- a/tests/tool/__snapshots__/test_build_all.ambr
+++ b/tests/tool/__snapshots__/test_build_all.ambr
@@ -1731,6 +1731,7 @@
       mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
       operation: copy
     ref:
+      digest: sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391
       tag: 6.7.1
     secretRef:
       name: podinfo-pull-secret

--- a/tests/tool/__snapshots__/test_build_ks.ambr
+++ b/tests/tool/__snapshots__/test_build_ks.ambr
@@ -673,6 +673,7 @@
       mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
       operation: copy
     ref:
+      digest: sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391
       tag: 6.7.1
     secretRef:
       name: podinfo-pull-secret
@@ -1738,6 +1739,7 @@
       mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
       operation: copy
     ref:
+      digest: sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391
       tag: 6.7.1
     secretRef:
       name: podinfo-pull-secret

--- a/tests/tool/__snapshots__/test_get_cluster.ambr
+++ b/tests/tool/__snapshots__/test_get_cluster.ambr
@@ -703,6 +703,7 @@
         namespace: default
         url: oci://ghcr.io/stefanprodan/charts/podinfo
         ref:
+          digest: sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391
           tag: 6.7.1
         secret_ref:
           name: podinfo-pull-secret


### PR DESCRIPTION
Fixes #1101 by adding a check for `ref.digest` before setting `--version`, and if a `ref.digest` is set, adds it to the `repo.url` when figuring out the chart name.

Switched `cluster9` over to have both a tag and digest as a simple way to get test coverage for this, since there are other tag-only `OCIRepository` to test the tag-only path.