### PR TITLE
chore(deps): bump gitpython to >= 3.1.47 for CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{ name = "Allen Porter", email = "allen.porter@gmail.com" }]
 requires-python = ">=3.13"
 classifiers = []
 dependencies = [
-  "GitPython>=3.1.30",
+  "GitPython>=3.1.47",
   "PyYAML>=6.0",
   "aiofiles>=22.1.0",
   "mashumaro>=3.12",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles==25.1.0
-GitPython==3.1.46
+GitPython==3.1.47
 mashumaro==3.20
 pytest==8.4.2
 pytest-asyncio==1.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ ruff==0.15.2
 
 
 aiofiles==25.1.0
-GitPython==3.1.46
+GitPython==3.1.47
 mashumaro==3.20
 pytest-asyncio==1.3.0
 python-slugify>=8.0.1

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=22.1.0" },
-    { name = "gitpython", specifier = ">=3.1.30" },
+    { name = "gitpython", specifier = ">=3.1.47" },
     { name = "mashumaro", specifier = ">=3.12" },
     { name = "nest-asyncio", specifier = ">=1.5.6" },
     { name = "oras", specifier = ">=0.2.31" },
@@ -122,14 +122,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.47"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [GHSA-rpm5-65cw-6hj4](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-rpm5-65cw-6hj4)
- [GHSA-x2qx-6953-8485](https://github.com/gitpython-developers/GitPython/security/advisories/GHSA-x2qx-6953-8485)